### PR TITLE
Add image and field tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ file(open|create) ──► session_id ──► text / paragraph / table / docu
 
 ## Tools
 
-Five tools, each with an `action` parameter.
+Seven tools, each with an `action` parameter.
 
 ### `file` — session lifecycle
 
@@ -150,6 +150,27 @@ Paragraph indices are **1-based**, matching Word.
 | `export-pdf` | Export to PDF without touching the open document |
 | `save-as` | Save a copy in another format |
 
+### `image` — pictures
+
+| Action | Purpose |
+|---|---|
+| `list` | List inline images with index, size, alt text and link state |
+| `insert` | Insert a picture, optionally with `width`, `height`, `caption` and `alt_text` |
+| `resize` | Resize by `width`/`height` or by `scale_percent` |
+| `replace` | Swap the picture behind an index, keeping its size by default |
+| `delete` | Delete an image by index |
+| `set-alt-text` | Set the alternative text for accessibility |
+
+### `field` — fields and tables of contents
+
+| Action | Purpose |
+|---|---|
+| `list` | List all fields with index, type and field code |
+| `insert-toc` | Insert a table of contents (`upper_heading_level`, `lower_heading_level`) |
+| `update-toc` | Recalculate every table of contents |
+| `update-all` | Update all fields, including those in headers and footers |
+| `insert-page-number` | Add a page number to the header or footer |
+
 ---
 
 ## Responses
@@ -179,6 +200,11 @@ Every tool returns JSON. Failures are reported as structured payloads, never as 
 * **Style names are English.** Built-in styles (`Heading 1`, `Title`, `Table Grid`, …) are translated to Word's language-independent style ids, so they work on localized installations. Any other name is passed to Word as-is, which is how custom and localized styles are addressed. Note that Word *reports* styles under their localized name (`Überschrift 1` on a German install).
 * **New documents are written directly, not via Word.** `file(create)` writes an empty `.docx`/`.docm` package itself and then opens it. Creating documents through Word instead is unreliable on machines signed in to Microsoft 365, because AutoSave claims the new document for OneDrive and silently ignores the requested local path.
 * **Merged table cells** are returned as empty strings by `table(read)`.
+* **Image sizes are in points, not pixels** (72 pt = 1 inch). `image(insert)` and `image(resize)` keep the aspect ratio unless `lock_aspect_ratio` is set to `false`, so passing only `width` scales the height along with it.
+* **`image` only covers inline pictures.** Floating shapes, text boxes and charts are left untouched and do not appear in `image(list)`, so their presence does not shift image indexes.
+* **A table of contents only lists heading paragraphs.** `field(insert-toc)` returns `entry_count: 0` for a document without heading styles — apply `Heading 1`/`Heading 2` via `paragraph(add|set-style)` first, then run `field(update-toc)`.
+* **`field(update-all)` also walks headers and footers.** Word's `Document.Fields` covers the body only, which is why page numbers would otherwise never refresh.
+* **`image(insert)` with a caption uses Word's caption numbering**, so the caption reads `Figure 1 <your text>` (localized on non-English installations) and participates in a table of figures.
 
 ---
 
@@ -197,7 +223,7 @@ dotnet test WordMcp.sln --filter "Category!=RequiresWord"
 |---|---|
 | `src/WordMcp.ComInterop` | Word COM lifecycle: STA threading, sessions, OLE message filter, file validation |
 | `src/WordMcp.Core` | Command implementations and result models |
-| `src/WordMcp.McpServer` | stdio MCP server exposing the five tools |
+| `src/WordMcp.McpServer` | stdio MCP server exposing the seven tools |
 | `tests/WordMcp.Core.Tests` | Unit tests plus integration tests against a real Word |
 | `tests/WordMcp.McpServer.Tests` | Tool-layer unit tests, no Word required |
 

--- a/src/WordMcp.ComInterop/ComInteropConstants.cs
+++ b/src/WordMcp.ComInterop/ComInteropConstants.cs
@@ -111,9 +111,45 @@ public static class ComInteropConstants
     /// <summary>WdFindWrap.wdFindContinue = 1.</summary>
     public const int WdFindContinue = 1;
 
+    /// <summary>WdFieldType.wdFieldTOC = 13.</summary>
+    public const int WdFieldToc = 13;
+
+    /// <summary>WdFieldType.wdFieldNumPages = 26.</summary>
+    public const int WdFieldNumPages = 26;
+
+    /// <summary>WdFieldType.wdFieldPage = 33.</summary>
+    public const int WdFieldPage = 33;
+
+    /// <summary>WdHeaderFooterIndex.wdHeaderFooterPrimary = 1.</summary>
+    public const int WdHeaderFooterPrimary = 1;
+
+    /// <summary>WdInlineShapeType.wdInlineShapePicture = 3.</summary>
+    public const int WdInlineShapePicture = 3;
+
+    /// <summary>WdInlineShapeType.wdInlineShapeLinkedPicture = 4.</summary>
+    public const int WdInlineShapeLinkedPicture = 4;
+
+    /// <summary>MsoTriState.msoTrue = -1.</summary>
+    public const int MsoTrue = -1;
+
+    /// <summary>MsoTriState.msoFalse = 0.</summary>
+    public const int MsoFalse = 0;
+
+    /// <summary>WdCaptionLabelID.wdCaptionFigure = -1.</summary>
+    public const int WdCaptionFigure = -1;
+
+    /// <summary>WdCaptionPosition.wdCaptionPositionBelow = 1.</summary>
+    public const int WdCaptionPositionBelow = 1;
+
     #endregion
 
     #region Supported extensions
+
+    /// <summary>
+    /// Image formats that can be inserted through <c>InlineShapes.AddPicture</c>.
+    /// </summary>
+    public static readonly string[] SupportedImageExtensions =
+        [".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tif", ".tiff", ".emf", ".wmf", ".svg"];
 
     /// <summary>
     /// File extensions this server can open through Word COM automation.

--- a/src/WordMcp.ComInterop/Session/WordBatch.cs
+++ b/src/WordMcp.ComInterop/Session/WordBatch.cs
@@ -233,7 +233,20 @@ internal sealed class WordBatch : IWordBatch
 
     private T WaitForCompletion<T>(Task<T> task, CancellationToken cancellationToken)
     {
-        if (!task.Wait(_operationTimeout, cancellationToken))
+        bool completed;
+
+        try
+        {
+            completed = task.Wait(_operationTimeout, cancellationToken);
+        }
+        catch (AggregateException)
+        {
+            // Wait wraps failures; GetResult below rethrows the original exception so callers see
+            // the actual COM or argument error instead of an AggregateException.
+            completed = true;
+        }
+
+        if (!completed)
         {
             throw new TimeoutException(
                 $"Word operation on '{Path.GetFileName(_documentPath)}' exceeded " +
@@ -379,28 +392,7 @@ internal sealed class WordBatch : IWordBatch
 
         Word.Document doc = OpenDocument(app, normalizedPath);
 
-        // Our hand-written package contains no styles, whereas a document created through Word
-        // inherits the built-in ones from Normal.dotm. Copy them in so callers can use names like
-        // "Heading 1" or "Table Grid".
-        CopyBuiltInStyles(app, doc);
-
         return doc;
-    }
-
-    private static void CopyBuiltInStyles(Word.Application app, Word.Document doc)
-    {
-        try
-        {
-            string template = (string)((dynamic)app).NormalTemplate.FullName;
-            ((dynamic)doc).CopyStylesFromTemplate(template);
-        }
-        catch (COMException)
-        {
-            // A document without the built-in styles is still usable; only named styles fail.
-        }
-        catch (Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
-        {
-        }
     }
 
     private static Word.Document OpenDocument(Word.Application app, string normalizedPath)

--- a/src/WordMcp.Core/Commands/Field/FieldCommands.cs
+++ b/src/WordMcp.Core/Commands/Field/FieldCommands.cs
@@ -1,0 +1,357 @@
+using WordMcp.ComInterop;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.Field;
+
+/// <summary>
+/// Word COM implementation of <see cref="IFieldCommands"/>.
+/// </summary>
+public sealed class FieldCommands : IFieldCommands
+{
+    /// <inheritdoc />
+    public FieldListResult List(IWordBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic fields = ctx.Document.Fields;
+            int total = (int)fields.Count;
+
+            var list = new List<Models.FieldInfo>(total);
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                list.Add(Describe(fields[i], i));
+            }
+
+            return new FieldListResult
+            {
+                TotalCount = total,
+                Fields = list
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public FieldResult InsertTableOfContents(
+        IWordBatch batch,
+        int? paragraphIndex = null,
+        int upperHeadingLevel = 1,
+        int lowerHeadingLevel = 3,
+        bool includePageNumbers = true,
+        bool useHyperlinks = true)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(upperHeadingLevel, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(lowerHeadingLevel, 9);
+
+        if (lowerHeadingLevel < upperHeadingLevel)
+        {
+            throw new ArgumentException(
+                $"lowerHeadingLevel ({lowerHeadingLevel}) must not be smaller than " +
+                $"upperHeadingLevel ({upperHeadingLevel}).",
+                nameof(lowerHeadingLevel));
+        }
+
+        if (paragraphIndex is int p)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(p, 1);
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic range = ResolveInsertRange(doc, paragraphIndex);
+
+            dynamic toc = doc.TablesOfContents.Add(
+                range,
+                true,                 // UseHeadingStyles
+                upperHeadingLevel,
+                lowerHeadingLevel,
+                false,                // UseFields
+                Type.Missing,         // TableID
+                true,                 // RightAlignPageNumbers
+                includePageNumbers,
+                Type.Missing,         // AddedStyles
+                useHyperlinks);
+
+            toc.Update();
+
+            int entries = CountEntries(doc, toc);
+
+            string message = entries == 0
+                ? "Table of contents inserted but empty: no paragraph uses a heading style. " +
+                  "Apply 'Heading 1' and friends via paragraph(add|set-style), then run field(update-toc)."
+                : $"Table of contents inserted with {entries} entr{(entries == 1 ? "y" : "ies")}.";
+
+            return new FieldResult
+            {
+                UpdatedCount = 1,
+                EntryCount = entries,
+                Message = message
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public FieldResult UpdateTableOfContents(IWordBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic tocs = doc.TablesOfContents;
+            int total = (int)tocs.Count;
+
+            int entries = 0;
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                dynamic toc = tocs[i];
+                toc.Update();
+                entries += CountEntries(doc, toc);
+            }
+
+            return new FieldResult
+            {
+                UpdatedCount = total,
+                EntryCount = entries,
+                Message = total == 0
+                    ? "The document has no table of contents. Insert one with field(insert-toc)."
+                    : $"{total} table(s) of contents updated, {entries} entr{(entries == 1 ? "y" : "ies")} in total."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public FieldResult UpdateAll(IWordBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+
+            int updated = (int)doc.Fields.Count;
+            doc.Fields.Update();
+
+            // Page numbers live in headers and footers, which Document.Fields does not cover.
+            foreach (dynamic section in doc.Sections)
+            {
+                ct.ThrowIfCancellationRequested();
+                updated += UpdateHeaderFooterFields(section.Headers);
+                updated += UpdateHeaderFooterFields(section.Footers);
+            }
+
+            return new FieldResult
+            {
+                UpdatedCount = updated,
+                Message = $"{updated} field(s) updated."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public FieldResult InsertPageNumber(
+        IWordBatch batch,
+        string position = "footer",
+        string alignment = "center",
+        bool includeTotalPages = false)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        bool inHeader = ParsePosition(position);
+        int wdAlignment = WordConversions.ToWdAlignment(alignment);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            int inserted = 0;
+
+            foreach (dynamic section in doc.Sections)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                dynamic container = inHeader ? section.Headers : section.Footers;
+                dynamic range = container[ComInteropConstants.WdHeaderFooterPrimary].Range;
+
+                range.Text = string.Empty;
+                range.ParagraphFormat.Alignment = wdAlignment;
+
+                if (includeTotalPages)
+                {
+                    range.InsertAfter("Page ");
+                    range.Collapse(ComInteropConstants.WdCollapseEnd);
+                    doc.Fields.Add(range, ComInteropConstants.WdFieldPage);
+
+                    dynamic after = container[ComInteropConstants.WdHeaderFooterPrimary].Range;
+                    after.Collapse(ComInteropConstants.WdCollapseEnd);
+                    after.InsertAfter(" of ");
+                    after.Collapse(ComInteropConstants.WdCollapseEnd);
+                    doc.Fields.Add(after, ComInteropConstants.WdFieldNumPages);
+                }
+                else
+                {
+                    doc.Fields.Add(range, ComInteropConstants.WdFieldPage);
+                }
+
+                inserted++;
+            }
+
+            string where = inHeader ? "header" : "footer";
+
+            return new FieldResult
+            {
+                UpdatedCount = inserted,
+                Message = $"Page number inserted into the {where} of {inserted} section(s)."
+            };
+        });
+    }
+
+    private static bool ParsePosition(string position)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(position);
+
+        return position.Trim().ToLowerInvariant() switch
+        {
+            "footer" or "bottom" => false,
+            "header" or "top" => true,
+            _ => throw new ArgumentException(
+                $"Unknown position '{position}'. Use 'header' or 'footer'.", nameof(position))
+        };
+    }
+
+    private static dynamic ResolveInsertRange(dynamic doc, int? paragraphIndex)
+    {
+        if (paragraphIndex is not int index)
+        {
+            dynamic start = doc.Content;
+            start.Collapse(ComInteropConstants.WdCollapseStart);
+            return start;
+        }
+
+        int total = (int)doc.Paragraphs.Count;
+        if (index > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(paragraphIndex),
+                $"Paragraph {index} does not exist. The document has {total} paragraph(s).");
+        }
+
+        dynamic range = doc.Paragraphs[index].Range;
+        range.Collapse(ComInteropConstants.WdCollapseStart);
+        return range;
+    }
+
+    /// <summary>
+    /// Counts the entries of a table of contents.
+    /// </summary>
+    /// <remarks>
+    /// Word has no entry count, so the paragraphs of the field result are counted. An empty table
+    /// of contents still holds one placeholder paragraph, which is why blank lines are skipped.
+    /// </remarks>
+    /// <summary>
+    /// Counts the entries of a table of contents. Word exposes no entry count, and reading the
+    /// generated text does not work: an empty table still holds a placeholder paragraph, and every
+    /// paragraph inside the table reports a field because the whole table *is* one TOC field.
+    /// Counting the source paragraphs instead is exact and language independent, because
+    /// <c>OutlineLevel</c> carries the heading level regardless of the localised style name.
+    /// </summary>
+    private static int CountEntries(dynamic doc, dynamic toc)
+    {
+        try
+        {
+            int upper = (int)toc.UpperHeadingLevel;
+            int lower = (int)toc.LowerHeadingLevel;
+
+            var tocRanges = new List<(int Start, int End)>();
+            foreach (dynamic other in doc.TablesOfContents)
+            {
+                dynamic otherRange = other.Range;
+                tocRanges.Add(((int)otherRange.Start, (int)otherRange.End));
+            }
+
+            int count = 0;
+            foreach (dynamic paragraph in doc.Paragraphs)
+            {
+                int level = (int)paragraph.OutlineLevel;
+                if (level < upper || level > lower)
+                {
+                    continue;
+                }
+
+                // Skip anything living inside a table of contents; the generated entries keep the
+                // outline level of the heading they point at.
+                int start = (int)paragraph.Range.Start;
+                if (tocRanges.Exists(r => start >= r.Start && start < r.End))
+                {
+                    continue;
+                }
+
+                count++;
+            }
+
+            return count;
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            return 0;
+        }
+    }
+
+    private static int UpdateHeaderFooterFields(dynamic container)
+    {
+        int updated = 0;
+
+        foreach (dynamic headerFooter in container)
+        {
+            dynamic fields = headerFooter.Range.Fields;
+            int count = (int)fields.Count;
+            if (count == 0)
+            {
+                continue;
+            }
+
+            fields.Update();
+            updated += count;
+        }
+
+        return updated;
+    }
+
+    private static Models.FieldInfo Describe(dynamic field, int index)
+    {
+        string code;
+        try
+        {
+            code = ((string?)field.Code.Text ?? string.Empty).Trim();
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            code = string.Empty;
+        }
+
+        string result;
+        try
+        {
+            result = WordConversions.CleanRangeText((string?)field.Result.Text);
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            result = string.Empty;
+        }
+
+        return new Models.FieldInfo
+        {
+            Index = index,
+            Type = (int)field.Type,
+            Code = code,
+            Result = result
+        };
+    }
+}

--- a/src/WordMcp.Core/Commands/Field/IFieldCommands.cs
+++ b/src/WordMcp.Core/Commands/Field/IFieldCommands.cs
@@ -1,0 +1,85 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Field;
+
+/// <summary>
+/// Field operations: table of contents, page numbers and field updates.
+/// </summary>
+/// <remarks>
+/// Fields hold a code and a cached result. The result is only recalculated on update, so a freshly
+/// inserted table of contents stays empty until <c>update-toc</c> or <c>update-all</c> runs — the
+/// insert actions therefore update right away.
+/// </remarks>
+[ServiceCategory("field", "Field")]
+[McpTool("field",
+    Title = "Field Operations",
+    Description = "Insert a table of contents and page numbers, update fields and list them.")]
+public interface IFieldCommands
+{
+    /// <summary>
+    /// Lists all fields of the main document text.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <returns>The fields of the document.</returns>
+    [ServiceAction("list")]
+    FieldListResult List(IWordBatch batch);
+
+    /// <summary>
+    /// Inserts a table of contents and updates it immediately.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="paragraphIndex">
+    /// 1-based paragraph to insert before. When omitted the table of contents goes to the top.
+    /// </param>
+    /// <param name="upperHeadingLevel">Highest heading level to include. Defaults to 1.</param>
+    /// <param name="lowerHeadingLevel">Lowest heading level to include. Defaults to 3.</param>
+    /// <param name="includePageNumbers">Whether to show page numbers. Defaults to <c>true</c>.</param>
+    /// <param name="useHyperlinks">Whether entries link to their heading. Defaults to <c>true</c>.</param>
+    /// <returns>
+    /// The result, including the number of entries. An entry count of zero means the document has
+    /// no paragraphs with heading styles.
+    /// </returns>
+    [ServiceAction("insert-toc")]
+    FieldResult InsertTableOfContents(
+        IWordBatch batch,
+        int? paragraphIndex = null,
+        int upperHeadingLevel = 1,
+        int lowerHeadingLevel = 3,
+        bool includePageNumbers = true,
+        bool useHyperlinks = true);
+
+    /// <summary>
+    /// Updates every table of contents in the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <returns>The number of tables of contents updated.</returns>
+    [ServiceAction("update-toc")]
+    FieldResult UpdateTableOfContents(IWordBatch batch);
+
+    /// <summary>
+    /// Updates all fields in the main text, headers and footers.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <returns>The number of fields updated.</returns>
+    [ServiceAction("update-all")]
+    FieldResult UpdateAll(IWordBatch batch);
+
+    /// <summary>
+    /// Inserts a page number field into the header or footer of every section.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="position">Either <c>footer</c> (default) or <c>header</c>.</param>
+    /// <param name="alignment">One of <c>left</c>, <c>center</c> (default) or <c>right</c>.</param>
+    /// <param name="includeTotalPages">
+    /// Whether to render "Page X of Y" instead of just the page number.
+    /// </param>
+    /// <returns>The number of page number fields inserted.</returns>
+    [ServiceAction("insert-page-number")]
+    FieldResult InsertPageNumber(
+        IWordBatch batch,
+        string position = "footer",
+        string alignment = "center",
+        bool includeTotalPages = false);
+}

--- a/src/WordMcp.Core/Commands/Image/IImageCommands.cs
+++ b/src/WordMcp.Core/Commands/Image/IImageCommands.cs
@@ -1,0 +1,102 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Image;
+
+/// <summary>
+/// Image operations on the inline images of a document.
+/// </summary>
+/// <remarks>
+/// Word keeps images in two separate collections: <c>InlineShapes</c> sit in the text flow like a
+/// character, <c>Shapes</c> float freely with their own anchor. These commands cover
+/// <c>InlineShapes</c> only, which is what inserting a picture produces by default.
+/// </remarks>
+[ServiceCategory("image", "Image")]
+[McpTool("image",
+    Title = "Image Operations",
+    Description = "Insert images, list them, resize, replace, delete and set alternative text.")]
+public interface IImageCommands
+{
+    /// <summary>
+    /// Lists all inline images of the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <returns>The images of the document.</returns>
+    [ServiceAction("list")]
+    ImageListResult List(IWordBatch batch);
+
+    /// <summary>
+    /// Inserts an image, by default at the end of the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="imagePath">Absolute path of the image file.</param>
+    /// <param name="paragraphIndex">
+    /// 1-based paragraph to insert before. When omitted the image is appended.
+    /// </param>
+    /// <param name="width">Optional width in points.</param>
+    /// <param name="height">Optional height in points.</param>
+    /// <param name="caption">Optional caption placed in a paragraph below the image.</param>
+    /// <param name="altText">Optional alternative text for screen readers.</param>
+    /// <returns>The inserted image.</returns>
+    [ServiceAction("insert")]
+    ImageResult Insert(
+        IWordBatch batch,
+        string imagePath,
+        int? paragraphIndex = null,
+        double? width = null,
+        double? height = null,
+        string? caption = null,
+        string? altText = null);
+
+    /// <summary>
+    /// Resizes an image, either to an absolute size in points or by a percentage.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based image index.</param>
+    /// <param name="width">Target width in points.</param>
+    /// <param name="height">Target height in points.</param>
+    /// <param name="scalePercent">Target size as a percentage of the current size.</param>
+    /// <param name="lockAspectRatio">
+    /// Whether Word adjusts the other dimension automatically. Defaults to <c>true</c>.
+    /// </param>
+    /// <returns>The resized image.</returns>
+    [ServiceAction("resize")]
+    ImageResult Resize(
+        IWordBatch batch,
+        int index,
+        double? width = null,
+        double? height = null,
+        double? scalePercent = null,
+        bool lockAspectRatio = true);
+
+    /// <summary>
+    /// Replaces the picture of an image while keeping its position and size.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based image index.</param>
+    /// <param name="imagePath">Absolute path of the new image file.</param>
+    /// <param name="keepSize">Whether to restore the previous size. Defaults to <c>true</c>.</param>
+    /// <returns>The replaced image.</returns>
+    [ServiceAction("replace")]
+    ImageResult Replace(IWordBatch batch, int index, string imagePath, bool keepSize = true);
+
+    /// <summary>
+    /// Deletes an image.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based image index.</param>
+    /// <returns>The result of the operation.</returns>
+    [ServiceAction("delete")]
+    ImageResult Delete(IWordBatch batch, int index);
+
+    /// <summary>
+    /// Sets the alternative text of an image.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based image index.</param>
+    /// <param name="altText">The alternative text.</param>
+    /// <returns>The updated image.</returns>
+    [ServiceAction("set-alt-text")]
+    ImageResult SetAltText(IWordBatch batch, int index, string altText);
+}

--- a/src/WordMcp.Core/Commands/Image/ImageCommands.cs
+++ b/src/WordMcp.Core/Commands/Image/ImageCommands.cs
@@ -1,0 +1,409 @@
+using WordMcp.ComInterop;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.Image;
+
+/// <summary>
+/// Word COM implementation of <see cref="IImageCommands"/>.
+/// </summary>
+public sealed class ImageCommands : IImageCommands
+{
+    /// <inheritdoc />
+    public ImageListResult List(IWordBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic shapes = ctx.Document.InlineShapes;
+            int total = (int)shapes.Count;
+
+            var list = new List<ImageInfo>(total);
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                list.Add(Describe(shapes[i], i));
+            }
+
+            return new ImageListResult
+            {
+                TotalCount = total,
+                Images = list
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ImageResult Insert(
+        IWordBatch batch,
+        string imagePath,
+        int? paragraphIndex = null,
+        double? width = null,
+        double? height = null,
+        string? caption = null,
+        string? altText = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentException.ThrowIfNullOrWhiteSpace(imagePath);
+
+        string fullPath = ValidateImagePath(imagePath);
+
+        if (paragraphIndex is int p)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(p, 1);
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic range = ResolveInsertRange(doc, paragraphIndex);
+
+            dynamic shape = doc.InlineShapes.AddPicture(fullPath, false, true, range);
+
+            ApplySize(shape, width, height, scalePercent: null, lockAspectRatio: true);
+
+            if (!string.IsNullOrEmpty(altText))
+            {
+                shape.AlternativeText = altText;
+            }
+
+            if (!string.IsNullOrWhiteSpace(caption))
+            {
+                InsertCaption(shape, caption);
+            }
+
+            int index = IndexOf(doc, shape);
+
+            return new ImageResult
+            {
+                Image = Describe(shape, index),
+                TotalCount = (int)doc.InlineShapes.Count,
+                Message = $"Image inserted at index {index}."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ImageResult Resize(
+        IWordBatch batch,
+        int index,
+        double? width = null,
+        double? height = null,
+        double? scalePercent = null,
+        bool lockAspectRatio = true)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(index, 1);
+
+        if (width is null && height is null && scalePercent is null)
+        {
+            throw new ArgumentException(
+                "Specify width, height or scalePercent.", nameof(scalePercent));
+        }
+
+        if (scalePercent is double s && s <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(scalePercent), scalePercent, "scalePercent must be greater than 0.");
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic shape = GetShape(doc, index);
+
+            ApplySize(shape, width, height, scalePercent, lockAspectRatio);
+
+            return new ImageResult
+            {
+                Image = Describe(shape, index),
+                TotalCount = (int)doc.InlineShapes.Count,
+                Message = $"Image {index} resized."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ImageResult Replace(IWordBatch batch, int index, string imagePath, bool keepSize = true)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentException.ThrowIfNullOrWhiteSpace(imagePath);
+        ArgumentOutOfRangeException.ThrowIfLessThan(index, 1);
+
+        string fullPath = ValidateImagePath(imagePath);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic old = GetShape(doc, index);
+
+            double oldWidth = (double)(float)old.Width;
+            double oldHeight = (double)(float)old.Height;
+            string oldAltText = ReadAltText(old);
+
+            // Anchor the replacement on the old picture's range so it lands in the same spot.
+            dynamic range = old.Range;
+            old.Delete();
+
+            dynamic shape = doc.InlineShapes.AddPicture(fullPath, false, true, range);
+
+            if (keepSize)
+            {
+                shape.LockAspectRatio = ComInteropConstants.MsoFalse;
+                shape.Width = (float)oldWidth;
+                shape.Height = (float)oldHeight;
+            }
+
+            if (!string.IsNullOrEmpty(oldAltText))
+            {
+                shape.AlternativeText = oldAltText;
+            }
+
+            int newIndex = IndexOf(doc, shape);
+
+            return new ImageResult
+            {
+                Image = Describe(shape, newIndex),
+                TotalCount = (int)doc.InlineShapes.Count,
+                Message = $"Image {newIndex} replaced with '{Path.GetFileName(fullPath)}'."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ImageResult Delete(IWordBatch batch, int index)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(index, 1);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            GetShape(doc, index).Delete();
+
+            return new ImageResult
+            {
+                TotalCount = (int)doc.InlineShapes.Count,
+                Message = $"Image {index} deleted."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ImageResult SetAltText(IWordBatch batch, int index, string altText)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(altText);
+        ArgumentOutOfRangeException.ThrowIfLessThan(index, 1);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic shape = GetShape(doc, index);
+            shape.AlternativeText = altText;
+
+            return new ImageResult
+            {
+                Image = Describe(shape, index),
+                TotalCount = (int)doc.InlineShapes.Count,
+                Message = $"Alternative text of image {index} updated."
+            };
+        });
+    }
+
+    /// <summary>
+    /// Validates that the path points at an existing image file Word can insert.
+    /// </summary>
+    private static string ValidateImagePath(string imagePath)
+    {
+        string fullPath = Path.GetFullPath(imagePath);
+
+        if (!File.Exists(fullPath))
+        {
+            throw new FileNotFoundException($"Image file not found: '{fullPath}'.", fullPath);
+        }
+
+        string extension = Path.GetExtension(fullPath).ToLowerInvariant();
+        if (!ComInteropConstants.SupportedImageExtensions.Contains(extension))
+        {
+            throw new ArgumentException(
+                $"Unsupported image format '{extension}'. Supported: " +
+                string.Join(", ", ComInteropConstants.SupportedImageExtensions) + ".",
+                nameof(imagePath));
+        }
+
+        return fullPath;
+    }
+
+    /// <summary>
+    /// Returns the range an inserted image should be anchored on.
+    /// </summary>
+    private static dynamic ResolveInsertRange(dynamic doc, int? paragraphIndex)
+    {
+        if (paragraphIndex is not int index)
+        {
+            dynamic end = doc.Content;
+            end.Collapse(ComInteropConstants.WdCollapseEnd);
+            end.InsertParagraphAfter();
+
+            dynamic target = doc.Content;
+            target.Collapse(ComInteropConstants.WdCollapseEnd);
+            return target;
+        }
+
+        int total = (int)doc.Paragraphs.Count;
+        if (index > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(paragraphIndex),
+                $"Paragraph {index} does not exist. The document has {total} paragraph(s).");
+        }
+
+        dynamic range = doc.Paragraphs[index].Range;
+        range.Collapse(ComInteropConstants.WdCollapseStart);
+        return range;
+    }
+
+    /// <summary>
+    /// Adds a caption below the image. The range of an inline shape covers the shape character
+    /// itself and rejects edits, so this uses Word's own caption machinery (which also numbers the
+    /// caption and makes it available to a table of figures) and only falls back to a plain
+    /// paragraph if that is unavailable.
+    /// </summary>
+    private static void InsertCaption(dynamic shape, string caption)
+    {
+        dynamic range = shape.Range;
+
+        try
+        {
+            range.InsertCaption(
+                ComInteropConstants.WdCaptionFigure,
+                " " + caption,
+                Type.Missing,
+                ComInteropConstants.WdCaptionPositionBelow,
+                false);
+            return;
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            // Fall through to the manual paragraph below.
+        }
+
+        dynamic paragraph = range.Paragraphs[1];
+        dynamic anchor = paragraph.Range;
+        anchor.InsertParagraphAfter();
+
+        dynamic captionRange = anchor.Paragraphs[anchor.Paragraphs.Count].Range;
+        captionRange.Text = caption;
+
+        try
+        {
+            captionRange.Style = WordStyles.Resolve("Caption");
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            // Without the Caption style the text is still there, just unstyled.
+        }
+    }
+
+    private static void ApplySize(
+        dynamic shape,
+        double? width,
+        double? height,
+        double? scalePercent,
+        bool lockAspectRatio)
+    {
+        if (scalePercent is double percent)
+        {
+            // ScaleWidth/ScaleHeight are relative to the original size, so scaling repeatedly
+            // would not compound. Deriving from the current size keeps it predictable.
+            double currentWidth = (double)(float)shape.Width;
+            double currentHeight = (double)(float)shape.Height;
+
+            shape.LockAspectRatio = ComInteropConstants.MsoFalse;
+            shape.Width = (float)(currentWidth * percent / 100d);
+            shape.Height = (float)(currentHeight * percent / 100d);
+            return;
+        }
+
+        if (width is null && height is null)
+        {
+            return;
+        }
+
+        shape.LockAspectRatio = lockAspectRatio
+            ? ComInteropConstants.MsoTrue
+            : ComInteropConstants.MsoFalse;
+
+        // With a locked aspect ratio Word derives the second dimension, so setting width last
+        // would silently override an explicit height.
+        if (width is double w)
+        {
+            shape.Width = (float)w;
+        }
+
+        if (height is double h)
+        {
+            shape.Height = (float)h;
+        }
+    }
+
+    private static dynamic GetShape(dynamic doc, int index)
+    {
+        int total = (int)doc.InlineShapes.Count;
+        if (index > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(index), $"Image {index} does not exist. The document has {total} image(s).");
+        }
+
+        return doc.InlineShapes[index];
+    }
+
+    /// <summary>
+    /// Finds the 1-based index of a shape by comparing range positions.
+    /// </summary>
+    /// <remarks>
+    /// <c>InlineShapes</c> has no IndexOf, and an inserted picture is not necessarily the last
+    /// element when it was anchored somewhere in the middle of the document.
+    /// </remarks>
+    private static int IndexOf(dynamic doc, dynamic shape)
+    {
+        int start = (int)shape.Range.Start;
+        int total = (int)doc.InlineShapes.Count;
+
+        for (int i = 1; i <= total; i++)
+        {
+            if ((int)doc.InlineShapes[i].Range.Start == start)
+            {
+                return i;
+            }
+        }
+
+        return total;
+    }
+
+    private static string ReadAltText(dynamic shape)
+    {
+        try
+        {
+            return (string?)shape.AlternativeText ?? string.Empty;
+        }
+        catch (System.Runtime.InteropServices.COMException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private static ImageInfo Describe(dynamic shape, int index) => new()
+    {
+        Index = index,
+        Width = Math.Round((double)(float)shape.Width, 2),
+        Height = Math.Round((double)(float)shape.Height, 2),
+        AltText = ReadAltText(shape),
+        LockAspectRatio = (int)shape.LockAspectRatio == ComInteropConstants.MsoTrue,
+        IsLinked = (int)shape.Type == ComInteropConstants.WdInlineShapeLinkedPicture
+    };
+}

--- a/src/WordMcp.Core/Models/FieldResults.cs
+++ b/src/WordMcp.Core/Models/FieldResults.cs
@@ -1,0 +1,49 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Metadata for a field in the document.
+/// </summary>
+public sealed class FieldInfo
+{
+    /// <summary>Gets or sets the 1-based field index.</summary>
+    public int Index { get; set; }
+
+    /// <summary>Gets or sets the numeric <c>WdFieldType</c> value.</summary>
+    public int Type { get; set; }
+
+    /// <summary>Gets or sets the field code, for example <c>TOC \o "1-3"</c>.</summary>
+    public string Code { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the last calculated field result.</summary>
+    public string Result { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// All fields of a document.
+/// </summary>
+public sealed class FieldListResult : ResultBase
+{
+    /// <summary>Gets or sets the total number of fields in the main text.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets the fields.</summary>
+    public IReadOnlyList<FieldInfo> Fields { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation that inserts or updates fields.
+/// </summary>
+public sealed class FieldResult : ResultBase
+{
+    /// <summary>Gets or sets the number of fields affected by the operation.</summary>
+    public int UpdatedCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of entries a table of contents contains after updating.
+    /// </summary>
+    /// <remarks>
+    /// Zero means the document has no paragraphs with heading styles, so the table of contents
+    /// is empty even though it was inserted successfully.
+    /// </remarks>
+    public int? EntryCount { get; set; }
+}

--- a/src/WordMcp.Core/Models/ImageResults.cs
+++ b/src/WordMcp.Core/Models/ImageResults.cs
@@ -1,0 +1,49 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Metadata for an inline image in the document.
+/// </summary>
+public sealed class ImageInfo
+{
+    /// <summary>Gets or sets the 1-based image index.</summary>
+    public int Index { get; set; }
+
+    /// <summary>Gets or sets the width in points.</summary>
+    public double Width { get; set; }
+
+    /// <summary>Gets or sets the height in points.</summary>
+    public double Height { get; set; }
+
+    /// <summary>Gets or sets the alternative text used by screen readers.</summary>
+    public string AltText { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether resizing keeps the aspect ratio.</summary>
+    public bool LockAspectRatio { get; set; }
+
+    /// <summary>Gets or sets whether the image is linked to a file instead of embedded.</summary>
+    public bool IsLinked { get; set; }
+}
+
+/// <summary>
+/// All inline images of a document.
+/// </summary>
+public sealed class ImageListResult : ResultBase
+{
+    /// <summary>Gets or sets the total number of inline images.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets the images.</summary>
+    public IReadOnlyList<ImageInfo> Images { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation that modifies an image.
+/// </summary>
+public sealed class ImageResult : ResultBase
+{
+    /// <summary>Gets or sets the affected image.</summary>
+    public ImageInfo? Image { get; set; }
+
+    /// <summary>Gets or sets the total number of inline images after the operation.</summary>
+    public int TotalCount { get; set; }
+}

--- a/src/WordMcp.McpServer/Program.cs
+++ b/src/WordMcp.McpServer/Program.cs
@@ -78,11 +78,14 @@ public static class Program
                     SESSION LIFECYCLE:
                     1. file(action:'open', path:'C:\\...\\report.docx') -> returns session_id
                        (or file(action:'create', path:...) for a new document)
-                    2. pass session_id to document / text / paragraph / table
+                    2. pass session_id to document / text / paragraph / table / image / field
                     3. file(action:'close', session_id:..., save:true) when completely done
 
-                    Paragraph and table indexes are 1-based and shift after structural edits;
-                    re-run paragraph(list) or table(list) before further edits.
+                    Paragraph, table and image indexes are 1-based and shift after structural
+                    edits; re-run paragraph(list), table(list) or image(list) before further edits.
+
+                    A table of contents only lists paragraphs that use a heading style, so apply
+                    'Heading 1'/'Heading 2' before calling field(insert-toc).
                     """;
             })
             .WithToolsFromAssembly()

--- a/src/WordMcp.McpServer/Tools/WordFieldTool.cs
+++ b/src/WordMcp.McpServer/Tools/WordFieldTool.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
+
+namespace WordMcp.McpServer.Tools;
+
+/// <summary>Actions of the <c>field</c> tool.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<WordFieldAction>))]
+public enum WordFieldAction
+{
+    /// <summary>List all fields.</summary>
+    [JsonStringEnumMemberName("list")] List,
+
+    /// <summary>Insert a table of contents.</summary>
+    [JsonStringEnumMemberName("insert-toc")] InsertToc,
+
+    /// <summary>Update every table of contents.</summary>
+    [JsonStringEnumMemberName("update-toc")] UpdateToc,
+
+    /// <summary>Update all fields.</summary>
+    [JsonStringEnumMemberName("update-all")] UpdateAll,
+
+    /// <summary>Insert a page number field.</summary>
+    [JsonStringEnumMemberName("insert-page-number")] InsertPageNumber
+}
+
+/// <summary>
+/// Field operations for an open Word session.
+/// </summary>
+[McpServerToolType]
+public static class WordFieldTool
+{
+    /// <summary>
+    /// Inserts and updates fields such as a table of contents and page numbers.
+    /// </summary>
+    /// <param name="action">The action to perform.</param>
+    /// <param name="session_id">Session identifier from file(open) or file(create).</param>
+    /// <param name="paragraph_index">1-based paragraph to insert before; inserts at the top when omitted.</param>
+    /// <param name="upper_heading_level">Highest heading level of the table of contents.</param>
+    /// <param name="lower_heading_level">Lowest heading level of the table of contents.</param>
+    /// <param name="include_page_numbers">Whether the table of contents shows page numbers.</param>
+    /// <param name="use_hyperlinks">Whether table of contents entries link to their heading.</param>
+    /// <param name="position">Either <c>footer</c> or <c>header</c> for page numbers.</param>
+    /// <param name="alignment">One of <c>left</c>, <c>center</c> or <c>right</c> for page numbers.</param>
+    /// <param name="include_total_pages">Whether to render "Page X of Y".</param>
+    /// <returns>A JSON payload describing the result.</returns>
+    [McpServerTool(Name = "field", Title = "Field Operations")]
+    [Description("Field operations on an open document. "
+        + "field(insert-toc, session_id, lower_heading_level=3) inserts a table of contents at the top "
+        + "and fills it immediately. It stays EMPTY unless paragraphs use heading styles, so apply "
+        + "'Heading 1'/'Heading 2' via paragraph(add, style=...) first; the result reports entry_count. "
+        + "field(insert-page-number, session_id, position='footer', alignment='center', include_total_pages=true) "
+        + "adds page numbers to every section. "
+        + "field(update-toc, session_id) refreshes the table of contents after content changed. "
+        + "field(update-all, session_id) refreshes every field including headers and footers. "
+        + "field(list, session_id) returns type, code and current result of each field.")]
+    public static string Field(
+        WordFieldAction action,
+        string session_id,
+        [DefaultValue(null)] int? paragraph_index = null,
+        [DefaultValue(1)] int upper_heading_level = 1,
+        [DefaultValue(3)] int lower_heading_level = 3,
+        [DefaultValue(true)] bool include_page_numbers = true,
+        [DefaultValue(true)] bool use_hyperlinks = true,
+        [DefaultValue("footer")] string position = "footer",
+        [DefaultValue("center")] string alignment = "center",
+        [DefaultValue(false)] bool include_total_pages = false)
+        => WordToolsBase.Execute("field", action.ToString(), () =>
+        {
+            var batch = WordToolsBase.Batch(session_id);
+
+            return action switch
+            {
+                WordFieldAction.List => WordServices.Fields.List(batch),
+                WordFieldAction.InsertToc => WordServices.Fields.InsertTableOfContents(
+                    batch,
+                    paragraph_index,
+                    upper_heading_level,
+                    lower_heading_level,
+                    include_page_numbers,
+                    use_hyperlinks),
+                WordFieldAction.UpdateToc => WordServices.Fields.UpdateTableOfContents(batch),
+                WordFieldAction.UpdateAll => WordServices.Fields.UpdateAll(batch),
+                WordFieldAction.InsertPageNumber => WordServices.Fields.InsertPageNumber(
+                    batch, position, alignment, include_total_pages),
+                _ => throw new ArgumentException($"Unknown action '{action}'.", nameof(action))
+            };
+        });
+}

--- a/src/WordMcp.McpServer/Tools/WordImageTool.cs
+++ b/src/WordMcp.McpServer/Tools/WordImageTool.cs
@@ -1,0 +1,117 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
+
+namespace WordMcp.McpServer.Tools;
+
+/// <summary>Actions of the <c>image</c> tool.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<WordImageAction>))]
+public enum WordImageAction
+{
+    /// <summary>List all inline images.</summary>
+    [JsonStringEnumMemberName("list")] List,
+
+    /// <summary>Insert an image.</summary>
+    [JsonStringEnumMemberName("insert")] Insert,
+
+    /// <summary>Resize an image.</summary>
+    [JsonStringEnumMemberName("resize")] Resize,
+
+    /// <summary>Replace the picture of an image.</summary>
+    [JsonStringEnumMemberName("replace")] Replace,
+
+    /// <summary>Delete an image.</summary>
+    [JsonStringEnumMemberName("delete")] Delete,
+
+    /// <summary>Set the alternative text of an image.</summary>
+    [JsonStringEnumMemberName("set-alt-text")] SetAltText
+}
+
+/// <summary>
+/// Image operations for an open Word session.
+/// </summary>
+[McpServerToolType]
+public static class WordImageTool
+{
+    /// <summary>
+    /// Inserts, lists and edits inline images.
+    /// </summary>
+    /// <param name="action">The action to perform.</param>
+    /// <param name="session_id">Session identifier from file(open) or file(create).</param>
+    /// <param name="image_path">Absolute path of the image file for insert and replace.</param>
+    /// <param name="index">1-based image index.</param>
+    /// <param name="paragraph_index">1-based paragraph to insert before; appends when omitted.</param>
+    /// <param name="width">Width in points.</param>
+    /// <param name="height">Height in points.</param>
+    /// <param name="scale_percent">Size as a percentage of the current size, for resize.</param>
+    /// <param name="lock_aspect_ratio">Whether resizing keeps the aspect ratio.</param>
+    /// <param name="keep_size">Whether replace restores the previous size.</param>
+    /// <param name="caption">Caption placed below the image on insert.</param>
+    /// <param name="alt_text">Alternative text for screen readers.</param>
+    /// <returns>A JSON payload describing the result.</returns>
+    [McpServerTool(Name = "image", Title = "Image Operations")]
+    [Description("Inline image operations on an open document. "
+        + "image(list, session_id) returns index, size and alt text of every image. "
+        + "image(insert, session_id, image_path='C:/pics/chart.png', width=300, caption='Figure 1') "
+        + "appends an image; pass paragraph_index to place it before a specific paragraph. "
+        + "image(resize, session_id, index=1, scale_percent=50) or (index=1, width=200) resizes. "
+        + "image(replace, session_id, index=1, image_path=...) swaps the picture but keeps position and size. "
+        + "image(delete|set-alt-text, session_id, index=1, ...) edits an existing image. "
+        + "Sizes are in points (1 point = 1/72 inch), not pixels. All indexes are 1-based. "
+        + "Only inline images are covered, not floating shapes.")]
+    public static string Image(
+        WordImageAction action,
+        string session_id,
+        [DefaultValue(null)] string? image_path = null,
+        [DefaultValue(null)] int? index = null,
+        [DefaultValue(null)] int? paragraph_index = null,
+        [DefaultValue(null)] double? width = null,
+        [DefaultValue(null)] double? height = null,
+        [DefaultValue(null)] double? scale_percent = null,
+        [DefaultValue(true)] bool lock_aspect_ratio = true,
+        [DefaultValue(true)] bool keep_size = true,
+        [DefaultValue(null)] string? caption = null,
+        [DefaultValue(null)] string? alt_text = null)
+        => WordToolsBase.Execute("image", action.ToString(), () =>
+        {
+            var batch = WordToolsBase.Batch(session_id);
+
+            return action switch
+            {
+                WordImageAction.List => WordServices.Images.List(batch),
+                WordImageAction.Insert => WordServices.Images.Insert(
+                    batch,
+                    RequireText(image_path, nameof(image_path)),
+                    paragraph_index,
+                    width,
+                    height,
+                    caption,
+                    alt_text),
+                WordImageAction.Resize => WordServices.Images.Resize(
+                    batch,
+                    Require(index, nameof(index)),
+                    width,
+                    height,
+                    scale_percent,
+                    lock_aspect_ratio),
+                WordImageAction.Replace => WordServices.Images.Replace(
+                    batch,
+                    Require(index, nameof(index)),
+                    RequireText(image_path, nameof(image_path)),
+                    keep_size),
+                WordImageAction.Delete => WordServices.Images.Delete(
+                    batch, Require(index, nameof(index))),
+                WordImageAction.SetAltText => WordServices.Images.SetAltText(
+                    batch, Require(index, nameof(index)), alt_text ?? string.Empty),
+                _ => throw new ArgumentException($"Unknown action '{action}'.", nameof(action))
+            };
+        });
+
+    private static int Require(int? value, string name)
+        => value ?? throw new ArgumentException($"{name} is required for this action.", name);
+
+    private static string RequireText(string? value, string name)
+        => string.IsNullOrWhiteSpace(value)
+            ? throw new ArgumentException($"{name} is required for this action.", name)
+            : value;
+}

--- a/src/WordMcp.McpServer/WordServices.cs
+++ b/src/WordMcp.McpServer/WordServices.cs
@@ -1,6 +1,8 @@
 using Microsoft.Extensions.Logging;
 using WordMcp.ComInterop.Session;
 using WordMcp.Core.Commands.Document;
+using WordMcp.Core.Commands.Field;
+using WordMcp.Core.Commands.Image;
 using WordMcp.Core.Commands.Paragraph;
 using WordMcp.Core.Commands.Table;
 using WordMcp.Core.Commands.Text;
@@ -45,6 +47,12 @@ internal static class WordServices
 
     /// <summary>Gets the table command implementation.</summary>
     public static ITableCommands Tables { get; } = new TableCommands();
+
+    /// <summary>Gets the image command implementation.</summary>
+    public static IImageCommands Images { get; } = new ImageCommands();
+
+    /// <summary>Gets the field command implementation.</summary>
+    public static IFieldCommands Fields { get; } = new FieldCommands();
 
     /// <summary>
     /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.

--- a/tests/WordMcp.Core.Tests/ImageAndFieldIntegrationTests.cs
+++ b/tests/WordMcp.Core.Tests/ImageAndFieldIntegrationTests.cs
@@ -1,0 +1,221 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.Field;
+using WordMcp.Core.Commands.Image;
+using WordMcp.Core.Commands.Paragraph;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Integration tests for the image and field commands. They run against their own document
+/// because both add structure (pictures, a table of contents, page numbers) that would interfere
+/// with the assertions of the shared fixture.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class ImageAndFieldIntegrationTests : IDisposable
+{
+    private static readonly ImageCommands Images = new();
+    private static readonly FieldCommands Fields = new();
+    private static readonly ParagraphCommands Paragraphs = new();
+
+    private readonly SessionManager _sessions = new();
+    private readonly string _directory;
+    private readonly string _sessionId;
+
+    private IWordBatch Batch => _sessions.GetBatch(_sessionId);
+
+    public ImageAndFieldIntegrationTests()
+    {
+        _directory = Directory
+            .CreateDirectory(Path.Combine(Path.GetTempPath(), "wordmcp-imgfld-" + Guid.NewGuid().ToString("N")))
+            .FullName;
+
+        _sessionId = _sessions.Create(Path.Combine(_directory, "images.docx")).SessionId;
+    }
+
+    [Fact]
+    public void Image_InsertListResizeReplaceAndDelete()
+    {
+        string red = CreateImage("red.bmp", 0x00, 0x00, 0xFF, 40, 20);
+        string blue = CreateImage("blue.bmp", 0xFF, 0x00, 0x00, 40, 20);
+
+        var inserted = Images.Insert(Batch, red, width: 120, caption: "Figure 1", altText: "A red rectangle");
+
+        Assert.True(inserted.Success);
+        Assert.NotNull(inserted.Image);
+        Assert.Equal(1, inserted.TotalCount);
+        Assert.Equal("A red rectangle", inserted.Image!.AltText);
+        Assert.Equal(120, inserted.Image.Width, 1);
+
+        // A locked aspect ratio has to scale the height along with the width.
+        Assert.Equal(60, inserted.Image.Height, 1);
+
+        var list = Images.List(Batch);
+        Assert.Equal(1, list.TotalCount);
+        Assert.False(list.Images[0].IsLinked);
+
+        var resized = Images.Resize(Batch, 1, scalePercent: 50);
+        Assert.Equal(60, resized.Image!.Width, 1);
+        Assert.Equal(30, resized.Image.Height, 1);
+
+        var replaced = Images.Replace(Batch, 1, blue);
+        Assert.Equal(60, replaced.Image!.Width, 1);
+        Assert.Equal(30, replaced.Image.Height, 1);
+        Assert.Equal("A red rectangle", replaced.Image.AltText);
+
+        var relabelled = Images.SetAltText(Batch, 1, "A blue rectangle");
+        Assert.Equal("A blue rectangle", relabelled.Image!.AltText);
+
+        var deleted = Images.Delete(Batch, 1);
+        Assert.Equal(0, deleted.TotalCount);
+    }
+
+    [Fact]
+    public void Image_ResizeWithoutAspectRatioUsesBothDimensions()
+    {
+        string image = CreateImage("free.bmp", 0x00, 0xFF, 0x00, 40, 20);
+        Images.Insert(Batch, image);
+
+        var resized = Images.Resize(Batch, 1, width: 200, height: 50, lockAspectRatio: false);
+
+        Assert.Equal(200, resized.Image!.Width, 1);
+        Assert.Equal(50, resized.Image.Height, 1);
+    }
+
+    [Fact]
+    public void Image_RejectsMissingFileAndUnsupportedFormat()
+    {
+        Assert.Throws<FileNotFoundException>(
+            () => Images.Insert(Batch, Path.Combine(_directory, "nope.png")));
+
+        string text = Path.Combine(_directory, "not-an-image.txt");
+        File.WriteAllText(text, "hello");
+        Assert.Throws<ArgumentException>(() => Images.Insert(Batch, text));
+    }
+
+    [Fact]
+    public void Image_RejectsOutOfRangeIndex()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => Images.Delete(Batch, 99));
+    }
+
+    [Fact]
+    public void Field_TableOfContentsIsEmptyWithoutHeadings()
+    {
+        Paragraphs.Add(Batch, "Just body text, no heading style.");
+
+        var toc = Fields.InsertTableOfContents(Batch);
+
+        Assert.True(toc.Success);
+        Assert.Equal(0, toc.EntryCount);
+        Assert.Contains("heading style", toc.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Field_TableOfContentsPicksUpHeadings()
+    {
+        Paragraphs.Add(Batch, "First chapter", style: "Heading 1");
+        Paragraphs.Add(Batch, "Some body text.");
+        Paragraphs.Add(Batch, "A section", style: "Heading 2");
+        Paragraphs.Add(Batch, "More body text.");
+
+        var toc = Fields.InsertTableOfContents(Batch, lowerHeadingLevel: 2);
+
+        Assert.True(toc.Success);
+        Assert.Equal(2, toc.EntryCount);
+
+        var updated = Fields.UpdateTableOfContents(Batch);
+        Assert.Equal(1, updated.UpdatedCount);
+        Assert.Equal(2, updated.EntryCount);
+
+        var fields = Fields.List(Batch);
+        Assert.Contains(fields.Fields, f => f.Code.Contains("TOC", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Field_RejectsInvertedHeadingLevels()
+    {
+        Assert.Throws<ArgumentException>(
+            () => Fields.InsertTableOfContents(Batch, upperHeadingLevel: 3, lowerHeadingLevel: 1));
+    }
+
+    [Fact]
+    public void Field_InsertsPageNumberAndUpdatesAll()
+    {
+        var inserted = Fields.InsertPageNumber(Batch, includeTotalPages: true);
+
+        Assert.True(inserted.Success);
+        Assert.True(inserted.UpdatedCount >= 1);
+
+        // Header and footer fields are invisible to Document.Fields, so update-all has to walk
+        // the sections to reach them.
+        var updated = Fields.UpdateAll(Batch);
+        Assert.True(updated.UpdatedCount >= 2);
+    }
+
+    [Fact]
+    public void Field_RejectsUnknownPosition()
+    {
+        Assert.Throws<ArgumentException>(() => Fields.InsertPageNumber(Batch, position: "sidebar"));
+    }
+
+    /// <summary>
+    /// Writes an uncompressed 24-bit BMP so the tests do not need an image fixture on disk.
+    /// </summary>
+    private string CreateImage(string name, byte b, byte g, byte r, int width, int height)
+    {
+        string path = Path.Combine(_directory, name);
+
+        int rowSize = ((width * 3) + 3) / 4 * 4;
+        int pixelDataSize = rowSize * height;
+        const int headerSize = 54;
+
+        var buffer = new byte[headerSize + pixelDataSize];
+
+        buffer[0] = (byte)'B';
+        buffer[1] = (byte)'M';
+        WriteInt32(buffer, 2, buffer.Length);
+        WriteInt32(buffer, 10, headerSize);
+        WriteInt32(buffer, 14, 40);
+        WriteInt32(buffer, 18, width);
+        WriteInt32(buffer, 22, height);
+        buffer[26] = 1;
+        buffer[28] = 24;
+        WriteInt32(buffer, 34, pixelDataSize);
+        WriteInt32(buffer, 38, 2835);
+        WriteInt32(buffer, 42, 2835);
+
+        for (int y = 0; y < height; y++)
+        {
+            int offset = headerSize + (y * rowSize);
+            for (int x = 0; x < width; x++)
+            {
+                buffer[offset + (x * 3)] = b;
+                buffer[offset + (x * 3) + 1] = g;
+                buffer[offset + (x * 3) + 2] = r;
+            }
+        }
+
+        File.WriteAllBytes(path, buffer);
+        return path;
+    }
+
+    private static void WriteInt32(byte[] buffer, int offset, int value)
+        => BitConverter.GetBytes(value).CopyTo(buffer, offset);
+
+    public void Dispose()
+    {
+        _sessions.Dispose();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/tests/WordMcp.Core.Tests/ImageAndFieldValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/ImageAndFieldValidationTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.Field;
+using WordMcp.Core.Commands.Image;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Argument validation of the image and field commands. All of it runs before the batch is
+/// touched, so these tests need no Word installation and run in CI.
+/// </summary>
+public class ImageAndFieldValidationTests
+{
+    private static readonly ImageCommands Images = new();
+    private static readonly FieldCommands Fields = new();
+    private static readonly ThrowingBatch Batch = new();
+
+    [Fact]
+    public void Insert_RejectsMissingFile()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "wordmcp-does-not-exist-" + Guid.NewGuid().ToString("N") + ".png");
+
+        Assert.Throws<FileNotFoundException>(() => Images.Insert(Batch, path));
+    }
+
+    [Fact]
+    public void Insert_RejectsUnsupportedExtension()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "wordmcp-" + Guid.NewGuid().ToString("N") + ".txt");
+        File.WriteAllText(path, "not an image");
+
+        try
+        {
+            var ex = Assert.Throws<ArgumentException>(() => Images.Insert(Batch, path));
+            Assert.Contains(".txt", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Insert_RejectsEmptyPath()
+        => Assert.Throws<ArgumentException>(() => Images.Insert(Batch, "  "));
+
+    [Fact]
+    public void Insert_RejectsParagraphIndexBelowOne()
+    {
+        string path = CreateSupportedFile();
+
+        try
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Images.Insert(Batch, path, paragraphIndex: 0));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void Resize_RequiresAtLeastOneDimension()
+        => Assert.Throws<ArgumentException>(() => Images.Resize(Batch, 1));
+
+    [Fact]
+    public void Resize_RejectsNonPositiveScale()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Images.Resize(Batch, 1, scalePercent: 0));
+
+    [Fact]
+    public void Resize_RejectsIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Images.Resize(Batch, 0, width: 100));
+
+    [Fact]
+    public void Delete_RejectsIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Images.Delete(Batch, 0));
+
+    [Fact]
+    public void SetAltText_RejectsIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Images.SetAltText(Batch, 0, "text"));
+
+    [Theory]
+    [InlineData(0, 3)]
+    [InlineData(1, 10)]
+    public void InsertToc_RejectsHeadingLevelsOutsideOneToNine(int upper, int lower)
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => Fields.InsertTableOfContents(Batch, upperHeadingLevel: upper, lowerHeadingLevel: lower));
+
+    [Fact]
+    public void InsertToc_RejectsInvertedHeadingLevels()
+        => Assert.Throws<ArgumentException>(
+            () => Fields.InsertTableOfContents(Batch, upperHeadingLevel: 3, lowerHeadingLevel: 2));
+
+    [Theory]
+    [InlineData("sidebar")]
+    [InlineData("")]
+    public void InsertPageNumber_RejectsUnknownPosition(string position)
+        => Assert.Throws<ArgumentException>(() => Fields.InsertPageNumber(Batch, position));
+
+    [Theory]
+    [InlineData("footer")]
+    [InlineData("bottom")]
+    [InlineData("header")]
+    [InlineData("top")]
+    public void InsertPageNumber_AcceptsKnownPositions(string position)
+    {
+        // Reaching the batch means validation passed — the fake batch then makes it fail loudly.
+        Assert.Throws<NotSupportedException>(() => Fields.InsertPageNumber(Batch, position));
+    }
+
+    [Fact]
+    public void Commands_RejectNullBatch()
+    {
+        Assert.Throws<ArgumentNullException>(() => Images.List(null!));
+        Assert.Throws<ArgumentNullException>(() => Fields.List(null!));
+    }
+
+    private static string CreateSupportedFile()
+    {
+        string path = Path.Combine(Path.GetTempPath(), "wordmcp-" + Guid.NewGuid().ToString("N") + ".png");
+        File.WriteAllBytes(path, [0x89, 0x50, 0x4E, 0x47]);
+        return path;
+    }
+
+    /// <summary>
+    /// Stands in for a Word batch. Any call means validation let the request through, which is
+    /// exactly what these tests assert.
+    /// </summary>
+    private sealed class ThrowingBatch : IWordBatch
+    {
+        public string DocumentPath => "fake.docx";
+
+        public ILogger Logger => NullLogger.Instance;
+
+        public TimeSpan OperationTimeout => TimeSpan.FromSeconds(30);
+
+        public int? WordProcessId => null;
+
+        public T Execute<T>(Func<WordContext, CancellationToken, T> operation, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Reached the batch.");
+
+        public void Execute(Action<WordContext, CancellationToken> operation, CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Reached the batch.");
+
+        public void Save(CancellationToken cancellationToken = default)
+            => throw new NotSupportedException("Reached the batch.");
+
+        public bool IsWordProcessAlive() => true;
+
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/tests/WordMcp.McpServer.Tests/WordToolContractTests.cs
+++ b/tests/WordMcp.McpServer.Tests/WordToolContractTests.cs
@@ -1,0 +1,70 @@
+using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using WordMcp.McpServer.Tools;
+using Xunit;
+
+namespace WordMcp.McpServer.Tests;
+
+/// <summary>
+/// Contract tests for the tool layer that need no Word installation.
+/// </summary>
+public class WordToolContractTests
+{
+    public static TheoryData<Type> ActionEnums =>
+    [
+        typeof(WordImageAction),
+        typeof(WordFieldAction)
+    ];
+
+    [Theory]
+    [MemberData(nameof(ActionEnums))]
+    public void ActionEnums_ExposeKebabCaseNamesToClients(Type enumType)
+    {
+        foreach (var member in enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            var attribute = member.GetCustomAttribute<JsonStringEnumMemberNameAttribute>();
+
+            Assert.True(attribute is not null, $"{enumType.Name}.{member.Name} has no wire name.");
+            Assert.Equal(attribute!.Name, attribute.Name.ToLowerInvariant());
+            Assert.DoesNotContain(" ", attribute.Name, StringComparison.Ordinal);
+            Assert.DoesNotContain("_", attribute.Name, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void Image_ReportsUnknownSessionAsStructuredError()
+    {
+        var json = WordImageTool.Image(WordImageAction.List, "word-does-not-exist");
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Equal("image", root.GetProperty("tool").GetString());
+        Assert.Equal("List", root.GetProperty("action").GetString());
+    }
+
+    [Fact]
+    public void Field_ReportsUnknownSessionAsStructuredError()
+    {
+        var json = WordFieldTool.Field(WordFieldAction.List, "word-does-not-exist");
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("success").GetBoolean());
+        Assert.Equal("field", root.GetProperty("tool").GetString());
+    }
+
+    [Fact]
+    public void Field_ValidatesArgumentsBeforeTouchingTheSession()
+    {
+        // A bad position must be reported as such, not swallowed by the missing session.
+        var json = WordFieldTool.Field(
+            WordFieldAction.InsertToc, "word-does-not-exist", upper_heading_level: 5, lower_heading_level: 1);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.False(doc.RootElement.GetProperty("success").GetBoolean());
+    }
+}


### PR DESCRIPTION
Adds the two remaining Phase 2 tools, closing out Epic #4's image and field scope.

## `image` — inline pictures

| Action | Purpose |
|---|---|
| `list` | Index, size, alt text, link state |
| `insert` | Optional `width`, `height`, `caption`, `alt_text` |
| `resize` | By dimension or by `scale_percent` |
| `replace` | Swap the picture behind an index, keeping its size |
| `delete` | Delete by index |
| `set-alt-text` | Accessibility text |

Only inline shapes are covered, per the issue scope. Sizes are in points, and the aspect ratio is kept unless the caller opts out.

## `field` — fields and tables of contents

| Action | Purpose |
|---|---|
| `list` | Index, type, field code |
| `insert-toc` | `upper_heading_level`, `lower_heading_level`, page numbers, hyperlinks |
| `update-toc` | Recalculate every table of contents |
| `update-all` | Update all fields, headers and footers included |
| `insert-page-number` | Header or footer, optional "Page X of Y" |

## Things that needed a second attempt

**Captions.** `shape.Range.InsertParagraphAfter()` fails with "cannot edit range" — the range of an inline shape covers the shape character itself. Switched to Word's own `InsertCaption`, which also numbers the caption and feeds a table of figures.

**Counting table-of-contents entries.** Word exposes no entry count, and reading the generated text does not work: an empty table still holds a placeholder paragraph, and every paragraph inside the table reports a field because the table itself *is* one field. The count is now derived from the outline level of the source paragraphs, which is exact and independent of the UI language.

## Supporting fixes

- `WordBatch.WaitForCompletion` no longer surfaces failures wrapped in an `AggregateException`. `Task.Wait` wraps, so callers — including MCP clients — saw `AggregateException` instead of the actual COM or argument error.
- Removed `CopyStylesFromTemplate` from document creation. It never had an effect (built-in styles are addressed through language-independent ids since #17) and cost a COM round trip per document. The full Word suite stays green without it.

## Testing

160 tests green: 140 without Word (the CI scope) and 20 against a real Word install, covering insert → list → resize → replace → set-alt-text → delete, a table of contents with and without headings, and page numbers with `update-all`.

Refs #16, #14