### PR TITLE
Add section and header/footer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ file(open|create) ──► session_id ──► text / paragraph / table / docu
 
 ## Tools
 
-Seven tools, each with an `action` parameter.
+Nine tools, each with an `action` parameter.
 
 ### `file` — session lifecycle
 
@@ -171,6 +171,24 @@ Paragraph indices are **1-based**, matching Word.
 | `update-all` | Update all fields, including those in headers and footers |
 | `insert-page-number` | Add a page number to the header or footer |
 
+### `section` — sections and page setup
+
+| Action | Purpose |
+|---|---|
+| `list` | List all sections with start type, margins, page size and orientation |
+| `add` | Insert a section break (`start_type`: `next-page`, `continuous`, `even-page`, `odd-page`) |
+| `page-setup` | Set margins, `orientation` and `paper_size` for one section or the whole document |
+
+### `header-footer` — headers and footers
+
+| Action | Purpose |
+|---|---|
+| `get` | Read the header or footer of one section or of all sections |
+| `set` | Write text, optionally with an `alignment` |
+| `clear` | Empty the header or footer |
+
+`kind` selects `header` or `footer`, `type` selects `primary`, `first-page` or `even-pages`.
+
 ---
 
 ## Responses
@@ -205,6 +223,10 @@ Every tool returns JSON. Failures are reported as structured payloads, never as 
 * **A table of contents only lists heading paragraphs.** `field(insert-toc)` returns `entry_count: 0` for a document without heading styles — apply `Heading 1`/`Heading 2` via `paragraph(add|set-style)` first, then run `field(update-toc)`.
 * **`field(update-all)` also walks headers and footers.** Word's `Document.Fields` covers the body only, which is why page numbers would otherwise never refresh.
 * **`image(insert)` with a caption uses Word's caption numbering**, so the caption reads `Figure 1 <your text>` (localized on non-English installations) and participates in a table of figures.
+* **All measurements are in points**, including page margins (1 cm = 28.35 pt, 1 inch = 72 pt).
+* **`section(page-setup)` applies `paper_size` before the margins**, because changing the paper size resets them in Word. Without a `section_index` the setup is applied to every section.
+* **Headers and footers are inherited between sections.** A new section shows the previous section's header until something is written to it. `header-footer(set)` with a `section_index` breaks that link automatically, so section 1 keeps its own text.
+* **`first-page` and `even-pages` headers need a section switch.** `header-footer(set)` turns on `DifferentFirstPage` respectively `DifferentOddEvenPages` for you — without it Word stores the text but never renders it.
 
 ---
 
@@ -223,7 +245,7 @@ dotnet test WordMcp.sln --filter "Category!=RequiresWord"
 |---|---|
 | `src/WordMcp.ComInterop` | Word COM lifecycle: STA threading, sessions, OLE message filter, file validation |
 | `src/WordMcp.Core` | Command implementations and result models |
-| `src/WordMcp.McpServer` | stdio MCP server exposing the seven tools |
+| `src/WordMcp.McpServer` | stdio MCP server exposing the nine tools |
 | `tests/WordMcp.Core.Tests` | Unit tests plus integration tests against a real Word |
 | `tests/WordMcp.McpServer.Tests` | Tool-layer unit tests, no Word required |
 

--- a/src/WordMcp.ComInterop/ComInteropConstants.cs
+++ b/src/WordMcp.ComInterop/ComInteropConstants.cs
@@ -141,6 +141,63 @@ public static class ComInteropConstants
     /// <summary>WdCaptionPosition.wdCaptionPositionBelow = 1.</summary>
     public const int WdCaptionPositionBelow = 1;
 
+    /// <summary>WdHeaderFooterIndex.wdHeaderFooterFirstPage = 2.</summary>
+    public const int WdHeaderFooterFirstPage = 2;
+
+    /// <summary>WdHeaderFooterIndex.wdHeaderFooterEvenPages = 3.</summary>
+    public const int WdHeaderFooterEvenPages = 3;
+
+    /// <summary>WdSectionStart.wdSectionContinuous = 0.</summary>
+    public const int WdSectionContinuous = 0;
+
+    /// <summary>WdSectionStart.wdSectionNewColumn = 1.</summary>
+    public const int WdSectionNewColumn = 1;
+
+    /// <summary>WdSectionStart.wdSectionNewPage = 2.</summary>
+    public const int WdSectionNewPage = 2;
+
+    /// <summary>WdSectionStart.wdSectionEvenPage = 3.</summary>
+    public const int WdSectionEvenPage = 3;
+
+    /// <summary>WdSectionStart.wdSectionOddPage = 4.</summary>
+    public const int WdSectionOddPage = 4;
+
+    /// <summary>WdBreakType.wdSectionBreakNextPage = 2.</summary>
+    public const int WdSectionBreakNextPage = 2;
+
+    /// <summary>WdBreakType.wdSectionBreakContinuous = 3.</summary>
+    public const int WdSectionBreakContinuous = 3;
+
+    /// <summary>WdBreakType.wdSectionBreakEvenPage = 4.</summary>
+    public const int WdSectionBreakEvenPage = 4;
+
+    /// <summary>WdBreakType.wdSectionBreakOddPage = 5.</summary>
+    public const int WdSectionBreakOddPage = 5;
+
+    /// <summary>WdOrientation.wdOrientPortrait = 0.</summary>
+    public const int WdOrientPortrait = 0;
+
+    /// <summary>WdOrientation.wdOrientLandscape = 1.</summary>
+    public const int WdOrientLandscape = 1;
+
+    /// <summary>WdPaperSize.wdPaperA4 = 7.</summary>
+    public const int WdPaperA4 = 7;
+
+    /// <summary>WdPaperSize.wdPaperA3 = 6.</summary>
+    public const int WdPaperA3 = 6;
+
+    /// <summary>WdPaperSize.wdPaperA5 = 8.</summary>
+    public const int WdPaperA5 = 8;
+
+    /// <summary>WdPaperSize.wdPaperLetter = 2.</summary>
+    public const int WdPaperLetter = 2;
+
+    /// <summary>WdPaperSize.wdPaperLegal = 5.</summary>
+    public const int WdPaperLegal = 5;
+
+    /// <summary>WdPaperSize.wdPaperTabloid = 16.</summary>
+    public const int WdPaperTabloid = 16;
+
     #endregion
 
     #region Supported extensions

--- a/src/WordMcp.Core/Commands/HeaderFooter/HeaderFooterCommands.cs
+++ b/src/WordMcp.Core/Commands/HeaderFooter/HeaderFooterCommands.cs
@@ -1,0 +1,217 @@
+using WordMcp.ComInterop;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.HeaderFooter;
+
+/// <summary>
+/// Word COM implementation of <see cref="IHeaderFooterCommands"/>.
+/// </summary>
+public sealed class HeaderFooterCommands : IHeaderFooterCommands
+{
+    /// <inheritdoc />
+    public HeaderFooterListResult Get(
+        IWordBatch batch,
+        string kind = "header",
+        int? sectionIndex = null,
+        string type = "primary")
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        bool isHeader = ParseKind(kind);
+        int wdType = WordConversions.ToWdHeaderFooterIndex(type);
+
+        if (sectionIndex is int s)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(s, 1);
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            var entries = new List<HeaderFooterInfo>();
+
+            foreach (int index in ResolveSections(doc, sectionIndex))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                dynamic section = doc.Sections[index];
+                entries.Add(Describe(section, index, isHeader, wdType));
+            }
+
+            return new HeaderFooterListResult
+            {
+                TotalCount = entries.Count,
+                HeadersFooters = entries
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public HeaderFooterResult Set(
+        IWordBatch batch,
+        string text,
+        string kind = "header",
+        int? sectionIndex = null,
+        string type = "primary",
+        string? alignment = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentNullException.ThrowIfNull(text);
+
+        return Write(batch, text, kind, sectionIndex, type, alignment);
+    }
+
+    /// <inheritdoc />
+    public HeaderFooterResult Clear(
+        IWordBatch batch,
+        string kind = "header",
+        int? sectionIndex = null,
+        string type = "primary")
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return Write(batch, string.Empty, kind, sectionIndex, type, alignment: null);
+    }
+
+    private static HeaderFooterResult Write(
+        IWordBatch batch,
+        string text,
+        string kind,
+        int? sectionIndex,
+        string type,
+        string? alignment)
+    {
+        bool isHeader = ParseKind(kind);
+        int wdType = WordConversions.ToWdHeaderFooterIndex(type);
+        int? wdAlignment = alignment is null ? null : WordConversions.ToWdAlignment(alignment);
+
+        if (sectionIndex is int s)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(s, 1);
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            var entries = new List<HeaderFooterInfo>();
+
+            foreach (int index in ResolveSections(doc, sectionIndex))
+            {
+                ct.ThrowIfCancellationRequested();
+
+                dynamic section = doc.Sections[index];
+
+                EnableType(section, wdType);
+
+                dynamic headerFooter = GetHeaderFooter(section, isHeader, wdType);
+
+                // A linked header shows the previous section's text and cannot be edited on its
+                // own, so writing to a specific section has to break the link first.
+                if (index > 1 && (bool)headerFooter.LinkToPrevious)
+                {
+                    headerFooter.LinkToPrevious = false;
+                }
+
+                dynamic range = headerFooter.Range;
+                range.Text = text;
+
+                if (wdAlignment is int align)
+                {
+                    range.ParagraphFormat.Alignment = align;
+                }
+
+                entries.Add(Describe(section, index, isHeader, wdType));
+            }
+
+            string what = isHeader ? "Header" : "Footer";
+            string action = text.Length == 0 ? "cleared" : "set";
+
+            return new HeaderFooterResult
+            {
+                UpdatedCount = entries.Count,
+                HeadersFooters = entries,
+                Message = $"{what} ({type}) {action} for {entries.Count} section(s)."
+            };
+        });
+    }
+
+    /// <summary>
+    /// Turns on the section switch that makes a first-page or even-pages header visible. Without
+    /// it Word stores the text but never renders it, which looks like a silent failure.
+    /// </summary>
+    private static void EnableType(dynamic section, int wdType)
+    {
+        dynamic pageSetup = section.PageSetup;
+
+        if (wdType == ComInteropConstants.WdHeaderFooterFirstPage)
+        {
+            pageSetup.DifferentFirstPageHeaderFooter = ComInteropConstants.MsoTrue;
+        }
+        else if (wdType == ComInteropConstants.WdHeaderFooterEvenPages)
+        {
+            pageSetup.OddAndEvenPagesHeaderFooter = ComInteropConstants.MsoTrue;
+        }
+    }
+
+    private static IEnumerable<int> ResolveSections(dynamic doc, int? sectionIndex)
+    {
+        int total = (int)doc.Sections.Count;
+
+        if (sectionIndex is not int index)
+        {
+            return Enumerable.Range(1, total);
+        }
+
+        if (index > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(sectionIndex),
+                $"Section {index} does not exist. The document has {total} section(s).");
+        }
+
+        return [index];
+    }
+
+    private static dynamic GetHeaderFooter(dynamic section, bool isHeader, int wdType)
+        => isHeader ? section.Headers[wdType] : section.Footers[wdType];
+
+    private static bool ParseKind(string kind)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+
+        return kind.Trim().ToLowerInvariant() switch
+        {
+            "header" or "top" => true,
+            "footer" or "bottom" => false,
+            _ => throw new ArgumentException(
+                $"Unknown kind '{kind}'. Use header or footer.", nameof(kind))
+        };
+    }
+
+    private static HeaderFooterInfo Describe(dynamic section, int index, bool isHeader, int wdType)
+    {
+        dynamic headerFooter = GetHeaderFooter(section, isHeader, wdType);
+        dynamic pageSetup = section.PageSetup;
+
+        bool isActive = wdType switch
+        {
+            ComInteropConstants.WdHeaderFooterFirstPage =>
+                (int)pageSetup.DifferentFirstPageHeaderFooter != 0,
+            ComInteropConstants.WdHeaderFooterEvenPages =>
+                (int)pageSetup.OddAndEvenPagesHeaderFooter != 0,
+            _ => true
+        };
+
+        return new HeaderFooterInfo
+        {
+            SectionIndex = index,
+            Kind = isHeader ? "header" : "footer",
+            Type = WordConversions.FromWdHeaderFooterIndex(wdType),
+            Text = WordConversions.CleanRangeText((string?)headerFooter.Range.Text),
+            LinkedToPrevious = index > 1 && (bool)headerFooter.LinkToPrevious,
+            IsActive = isActive
+        };
+    }
+}

--- a/src/WordMcp.Core/Commands/HeaderFooter/IHeaderFooterCommands.cs
+++ b/src/WordMcp.Core/Commands/HeaderFooter/IHeaderFooterCommands.cs
@@ -1,0 +1,76 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.HeaderFooter;
+
+/// <summary>
+/// Header and footer operations, per section and per page type.
+/// </summary>
+/// <remarks>
+/// Headers and footers belong to a section, not to the document. Two Word behaviours shape this
+/// API: a new section inherits its headers from the previous one until the link is broken, and the
+/// <c>first-page</c> and <c>even-pages</c> variants are only rendered once the matching switch is
+/// enabled on the section. Writing takes care of both.
+/// </remarks>
+[ServiceCategory("headerFooter", "HeaderFooter")]
+[McpTool("header-footer",
+    Title = "Header and Footer Operations",
+    Description = "Read, write and clear headers and footers per section and page type.")]
+public interface IHeaderFooterCommands
+{
+    /// <summary>
+    /// Reads headers or footers.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="kind">Either <c>header</c> or <c>footer</c>.</param>
+    /// <param name="sectionIndex">1-based section. When omitted all sections are returned.</param>
+    /// <param name="type">
+    /// <c>primary</c>, <c>first-page</c> or <c>even-pages</c>. Defaults to <c>primary</c>.
+    /// </param>
+    /// <returns>The matching headers or footers.</returns>
+    [ServiceAction("get")]
+    HeaderFooterListResult Get(
+        IWordBatch batch,
+        string kind = "header",
+        int? sectionIndex = null,
+        string type = "primary");
+
+    /// <summary>
+    /// Writes a header or footer.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="text">The text to write.</param>
+    /// <param name="kind">Either <c>header</c> or <c>footer</c>.</param>
+    /// <param name="sectionIndex">1-based section. When omitted every section is written.</param>
+    /// <param name="type">
+    /// <c>primary</c>, <c>first-page</c> or <c>even-pages</c>. Defaults to <c>primary</c>. The
+    /// matching section switch is enabled automatically, because Word would otherwise store the
+    /// text without ever rendering it.
+    /// </param>
+    /// <param name="alignment">Optional <c>left</c>, <c>center</c>, <c>right</c> or <c>justify</c>.</param>
+    /// <returns>The headers or footers after the change.</returns>
+    [ServiceAction("set")]
+    HeaderFooterResult Set(
+        IWordBatch batch,
+        string text,
+        string kind = "header",
+        int? sectionIndex = null,
+        string type = "primary",
+        string? alignment = null);
+
+    /// <summary>
+    /// Clears the content of a header or footer.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="kind">Either <c>header</c> or <c>footer</c>.</param>
+    /// <param name="sectionIndex">1-based section. When omitted every section is cleared.</param>
+    /// <param name="type"><c>primary</c>, <c>first-page</c> or <c>even-pages</c>.</param>
+    /// <returns>The headers or footers after the change.</returns>
+    [ServiceAction("clear")]
+    HeaderFooterResult Clear(
+        IWordBatch batch,
+        string kind = "header",
+        int? sectionIndex = null,
+        string type = "primary");
+}

--- a/src/WordMcp.Core/Commands/Section/ISectionCommands.cs
+++ b/src/WordMcp.Core/Commands/Section/ISectionCommands.cs
@@ -1,0 +1,69 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Section;
+
+/// <summary>
+/// Section operations: listing sections, adding section breaks and changing the page setup.
+/// </summary>
+/// <remarks>
+/// A section owns the page setup and the headers and footers. A document always has at least one
+/// section, so <c>list</c> never returns an empty result. All measurements are in points
+/// (72 pt = 1 inch), which is the unit Word uses internally.
+/// </remarks>
+[ServiceCategory("section", "Section")]
+[McpTool("section",
+    Title = "Section Operations",
+    Description = "List sections, insert section breaks and change margins, orientation and paper size.")]
+public interface ISectionCommands
+{
+    /// <summary>
+    /// Lists all sections with their page setup.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <returns>The sections of the document.</returns>
+    [ServiceAction("list")]
+    SectionListResult List(IWordBatch batch);
+
+    /// <summary>
+    /// Inserts a section break, which creates a new section.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="startType">
+    /// How the new section starts: <c>next-page</c>, <c>continuous</c>, <c>even-page</c> or
+    /// <c>odd-page</c>. Defaults to <c>next-page</c>.
+    /// </param>
+    /// <param name="paragraphIndex">
+    /// 1-based paragraph to insert the break after. When omitted the break goes to the end of the
+    /// document.
+    /// </param>
+    /// <returns>The new section.</returns>
+    [ServiceAction("add")]
+    SectionResult Add(IWordBatch batch, string startType = "next-page", int? paragraphIndex = null);
+
+    /// <summary>
+    /// Changes margins, orientation and paper size.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="sectionIndex">
+    /// 1-based section to change. When omitted the change applies to the whole document.
+    /// </param>
+    /// <param name="topMargin">Top margin in points.</param>
+    /// <param name="bottomMargin">Bottom margin in points.</param>
+    /// <param name="leftMargin">Left margin in points.</param>
+    /// <param name="rightMargin">Right margin in points.</param>
+    /// <param name="orientation">Either <c>portrait</c> or <c>landscape</c>.</param>
+    /// <param name="paperSize">A name such as <c>a4</c>, <c>letter</c> or <c>legal</c>.</param>
+    /// <returns>The page setup after the change.</returns>
+    [ServiceAction("page-setup")]
+    SectionResult PageSetup(
+        IWordBatch batch,
+        int? sectionIndex = null,
+        double? topMargin = null,
+        double? bottomMargin = null,
+        double? leftMargin = null,
+        double? rightMargin = null,
+        string? orientation = null,
+        string? paperSize = null);
+}

--- a/src/WordMcp.Core/Commands/Section/SectionCommands.cs
+++ b/src/WordMcp.Core/Commands/Section/SectionCommands.cs
@@ -1,0 +1,239 @@
+using WordMcp.ComInterop;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.Section;
+
+/// <summary>
+/// Word COM implementation of <see cref="ISectionCommands"/>.
+/// </summary>
+public sealed class SectionCommands : ISectionCommands
+{
+    /// <inheritdoc />
+    public SectionListResult List(IWordBatch batch)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic sections = ctx.Document.Sections;
+            int total = (int)sections.Count;
+
+            var list = new List<SectionInfo>(total);
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                list.Add(Describe(sections[i], i));
+            }
+
+            return new SectionListResult
+            {
+                TotalCount = total,
+                Sections = list
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public SectionResult Add(IWordBatch batch, string startType = "next-page", int? paragraphIndex = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        int breakType = WordConversions.ToWdSectionBreak(startType);
+
+        if (paragraphIndex is int p)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(p, 1);
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic range = ResolveBreakRange(doc, paragraphIndex);
+
+            range.InsertBreak(breakType);
+
+            int total = (int)doc.Sections.Count;
+
+            // The break splits the section that contained the range, so the new section is the one
+            // right after it rather than necessarily the last one.
+            int newIndex = (int)range.Sections[1].Index;
+            if (newIndex < total)
+            {
+                newIndex++;
+            }
+
+            return new SectionResult
+            {
+                Section = Describe(doc.Sections[newIndex], newIndex),
+                TotalCount = total,
+                Message = $"Section break inserted; the document now has {total} section(s)."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public SectionResult PageSetup(
+        IWordBatch batch,
+        int? sectionIndex = null,
+        double? topMargin = null,
+        double? bottomMargin = null,
+        double? leftMargin = null,
+        double? rightMargin = null,
+        string? orientation = null,
+        string? paperSize = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        if (sectionIndex is int s)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(s, 1);
+        }
+
+        ValidateMargin(topMargin, nameof(topMargin));
+        ValidateMargin(bottomMargin, nameof(bottomMargin));
+        ValidateMargin(leftMargin, nameof(leftMargin));
+        ValidateMargin(rightMargin, nameof(rightMargin));
+
+        if (topMargin is null && bottomMargin is null && leftMargin is null && rightMargin is null
+            && orientation is null && paperSize is null)
+        {
+            throw new ArgumentException(
+                "Specify at least one of topMargin, bottomMargin, leftMargin, rightMargin, "
+                + "orientation or paperSize.",
+                nameof(sectionIndex));
+        }
+
+        // Parsed up front so an unknown name fails before anything is written.
+        int? wdOrientation = orientation is null ? null : WordConversions.ToWdOrientation(orientation);
+        int? wdPaperSize = paperSize is null ? null : WordConversions.ToWdPaperSize(paperSize);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            int total = (int)doc.Sections.Count;
+
+            dynamic target = sectionIndex is int index
+                ? GetSection(doc, index, total)
+                : doc;
+
+            dynamic pageSetup = target.PageSetup;
+
+            // Paper size resets the margins, so it has to be applied before them.
+            if (wdPaperSize is int paper)
+            {
+                pageSetup.PaperSize = paper;
+            }
+
+            if (wdOrientation is int orient)
+            {
+                pageSetup.Orientation = orient;
+            }
+
+            if (topMargin is double top)
+            {
+                pageSetup.TopMargin = (float)top;
+            }
+
+            if (bottomMargin is double bottom)
+            {
+                pageSetup.BottomMargin = (float)bottom;
+            }
+
+            if (leftMargin is double left)
+            {
+                pageSetup.LeftMargin = (float)left;
+            }
+
+            if (rightMargin is double right)
+            {
+                pageSetup.RightMargin = (float)right;
+            }
+
+            int described = sectionIndex ?? 1;
+
+            return new SectionResult
+            {
+                Section = Describe(doc.Sections[described], described),
+                TotalCount = total,
+                Message = sectionIndex is null
+                    ? $"Page setup applied to all {total} section(s)."
+                    : $"Page setup applied to section {sectionIndex}."
+            };
+        });
+    }
+
+    private static void ValidateMargin(double? margin, string parameterName)
+    {
+        if (margin is double value && value < 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, value, "Margins cannot be negative.");
+        }
+    }
+
+    private static dynamic GetSection(dynamic doc, int index, int total)
+    {
+        if (index > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(index), $"Section {index} does not exist. The document has {total} section(s).");
+        }
+
+        return doc.Sections[index];
+    }
+
+    /// <summary>
+    /// Resolves the range the section break is inserted at. Without a paragraph the break goes to
+    /// the end of the document.
+    /// </summary>
+    private static dynamic ResolveBreakRange(dynamic doc, int? paragraphIndex)
+    {
+        if (paragraphIndex is not int index)
+        {
+            dynamic content = doc.Content;
+            content.Collapse(ComInteropConstants.WdCollapseEnd);
+            return content;
+        }
+
+        int total = (int)doc.Paragraphs.Count;
+        if (index > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(paragraphIndex),
+                $"Paragraph {index} does not exist. The document has {total} paragraph(s).");
+        }
+
+        dynamic range = doc.Paragraphs[index].Range;
+        range.Collapse(ComInteropConstants.WdCollapseEnd);
+        return range;
+    }
+
+    private static SectionInfo Describe(dynamic section, int index)
+    {
+        dynamic pageSetup = section.PageSetup;
+
+        return new SectionInfo
+        {
+            Index = index,
+            StartType = WordConversions.FromWdSectionStart((int)pageSetup.SectionStart),
+            DifferentFirstPage = (int)pageSetup.DifferentFirstPageHeaderFooter != 0,
+            DifferentOddEvenPages = (int)pageSetup.OddAndEvenPagesHeaderFooter != 0,
+            PageSetup = new PageSetupInfo
+            {
+                TopMargin = Round((double)pageSetup.TopMargin),
+                BottomMargin = Round((double)pageSetup.BottomMargin),
+                LeftMargin = Round((double)pageSetup.LeftMargin),
+                RightMargin = Round((double)pageSetup.RightMargin),
+                PageWidth = Round((double)pageSetup.PageWidth),
+                PageHeight = Round((double)pageSetup.PageHeight),
+                Orientation = WordConversions.FromWdOrientation((int)pageSetup.Orientation)
+            }
+        };
+    }
+
+    /// <summary>
+    /// Word stores measurements as single-precision floats, so values come back as 56.70000076.
+    /// </summary>
+    private static double Round(double value) => Math.Round(value, 2);
+}

--- a/src/WordMcp.Core/Models/HeaderFooterResults.cs
+++ b/src/WordMcp.Core/Models/HeaderFooterResults.cs
@@ -1,0 +1,60 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Content of a single header or footer.
+/// </summary>
+public sealed class HeaderFooterInfo
+{
+    /// <summary>Gets or sets the 1-based index of the owning section.</summary>
+    public int SectionIndex { get; set; }
+
+    /// <summary>Gets or sets the kind, either <c>header</c> or <c>footer</c>.</summary>
+    public string Kind { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the type: <c>primary</c>, <c>first-page</c> or <c>even-pages</c>.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the text content.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether this header or footer is inherited from the previous section.
+    /// </summary>
+    /// <remarks>
+    /// A linked header shows the text of the previous section and cannot be changed on its own;
+    /// writing to it unlinks it first.
+    /// </remarks>
+    public bool LinkedToPrevious { get; set; }
+
+    /// <summary>
+    /// Gets or sets whether the type is active. A <c>first-page</c> header is only rendered when
+    /// the section has <c>DifferentFirstPage</c> switched on.
+    /// </summary>
+    public bool IsActive { get; set; }
+}
+
+/// <summary>
+/// Headers or footers matching a query.
+/// </summary>
+public sealed class HeaderFooterListResult : ResultBase
+{
+    /// <summary>Gets or sets the total number of entries returned.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets the headers or footers.</summary>
+    public IReadOnlyList<HeaderFooterInfo> HeadersFooters { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation that writes to headers or footers.
+/// </summary>
+public sealed class HeaderFooterResult : ResultBase
+{
+    /// <summary>Gets or sets the number of headers or footers that were changed.</summary>
+    public int UpdatedCount { get; set; }
+
+    /// <summary>Gets or sets the entries as they are after the operation.</summary>
+    public IReadOnlyList<HeaderFooterInfo> HeadersFooters { get; set; } = [];
+}

--- a/src/WordMcp.Core/Models/SectionResults.cs
+++ b/src/WordMcp.Core/Models/SectionResults.cs
@@ -1,0 +1,76 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Page setup of a section. All measurements are in points (72 pt = 1 inch), which is the unit
+/// Word itself uses.
+/// </summary>
+public sealed class PageSetupInfo
+{
+    /// <summary>Gets or sets the top margin in points.</summary>
+    public double TopMargin { get; set; }
+
+    /// <summary>Gets or sets the bottom margin in points.</summary>
+    public double BottomMargin { get; set; }
+
+    /// <summary>Gets or sets the left margin in points.</summary>
+    public double LeftMargin { get; set; }
+
+    /// <summary>Gets or sets the right margin in points.</summary>
+    public double RightMargin { get; set; }
+
+    /// <summary>Gets or sets the page width in points.</summary>
+    public double PageWidth { get; set; }
+
+    /// <summary>Gets or sets the page height in points.</summary>
+    public double PageHeight { get; set; }
+
+    /// <summary>Gets or sets the orientation, either <c>portrait</c> or <c>landscape</c>.</summary>
+    public string Orientation { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Metadata for a section of the document.
+/// </summary>
+public sealed class SectionInfo
+{
+    /// <summary>Gets or sets the 1-based section index.</summary>
+    public int Index { get; set; }
+
+    /// <summary>
+    /// Gets or sets how the section starts, for example <c>next-page</c> or <c>continuous</c>.
+    /// </summary>
+    public string StartType { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the page setup of the section.</summary>
+    public PageSetupInfo PageSetup { get; set; } = new();
+
+    /// <summary>Gets or sets whether the first page has its own header and footer.</summary>
+    public bool DifferentFirstPage { get; set; }
+
+    /// <summary>Gets or sets whether odd and even pages have separate headers and footers.</summary>
+    public bool DifferentOddEvenPages { get; set; }
+}
+
+/// <summary>
+/// All sections of a document.
+/// </summary>
+public sealed class SectionListResult : ResultBase
+{
+    /// <summary>Gets or sets the total number of sections.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets the sections.</summary>
+    public IReadOnlyList<SectionInfo> Sections { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation that adds or changes a section.
+/// </summary>
+public sealed class SectionResult : ResultBase
+{
+    /// <summary>Gets or sets the affected section, when the operation targeted a single one.</summary>
+    public SectionInfo? Section { get; set; }
+
+    /// <summary>Gets or sets the total number of sections after the operation.</summary>
+    public int TotalCount { get; set; }
+}

--- a/src/WordMcp.Core/Utilities/WordConversions.cs
+++ b/src/WordMcp.Core/Utilities/WordConversions.cs
@@ -103,4 +103,160 @@ public static class WordConversions
         // Word stores colours as BGR, not RGB.
         return (b << 16) | (g << 8) | r;
     }
+
+    /// <summary>
+    /// Converts an orientation name to the matching <c>WdOrientation</c> value.
+    /// </summary>
+    /// <param name="orientation">Either <c>portrait</c> or <c>landscape</c>.</param>
+    /// <returns>The Word orientation constant.</returns>
+    /// <exception cref="ArgumentException">The orientation name is unknown.</exception>
+    public static int ToWdOrientation(string orientation)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(orientation);
+
+        return orientation.Trim().ToLowerInvariant() switch
+        {
+            "portrait" or "vertical" => ComInteropConstants.WdOrientPortrait,
+            "landscape" or "horizontal" => ComInteropConstants.WdOrientLandscape,
+            _ => throw new ArgumentException(
+                $"Unknown orientation '{orientation}'. Use portrait or landscape.", nameof(orientation))
+        };
+    }
+
+    /// <summary>
+    /// Converts a <c>WdOrientation</c> value to its friendly name.
+    /// </summary>
+    /// <param name="wdOrientation">The Word orientation constant.</param>
+    /// <returns>The friendly orientation name.</returns>
+    public static string FromWdOrientation(int wdOrientation) => wdOrientation switch
+    {
+        ComInteropConstants.WdOrientPortrait => "portrait",
+        ComInteropConstants.WdOrientLandscape => "landscape",
+        _ => "other"
+    };
+
+    /// <summary>
+    /// Converts a paper size name to the matching <c>WdPaperSize</c> value.
+    /// </summary>
+    /// <param name="paperSize">A name such as <c>a4</c>, <c>letter</c> or <c>legal</c>.</param>
+    /// <returns>The Word paper size constant.</returns>
+    /// <exception cref="ArgumentException">The paper size name is unknown.</exception>
+    public static int ToWdPaperSize(string paperSize)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(paperSize);
+
+        return paperSize.Trim().ToLowerInvariant().Replace(" ", string.Empty, StringComparison.Ordinal) switch
+        {
+            "a3" => ComInteropConstants.WdPaperA3,
+            "a4" => ComInteropConstants.WdPaperA4,
+            "a5" => ComInteropConstants.WdPaperA5,
+            "letter" => ComInteropConstants.WdPaperLetter,
+            "legal" => ComInteropConstants.WdPaperLegal,
+            "tabloid" => ComInteropConstants.WdPaperTabloid,
+            _ => throw new ArgumentException(
+                $"Unknown paper size '{paperSize}'. Use one of: a3, a4, a5, letter, legal, tabloid.",
+                nameof(paperSize))
+        };
+    }
+
+    /// <summary>
+    /// Converts a section start name to the matching <c>WdSectionStart</c> value.
+    /// </summary>
+    /// <param name="startType">
+    /// One of <c>next-page</c>, <c>continuous</c>, <c>even-page</c>, <c>odd-page</c> or
+    /// <c>new-column</c>.
+    /// </param>
+    /// <returns>The Word section start constant.</returns>
+    /// <exception cref="ArgumentException">The section start name is unknown.</exception>
+    public static int ToWdSectionStart(string startType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(startType);
+
+        return NormalizeName(startType) switch
+        {
+            "next-page" or "nextpage" or "page" => ComInteropConstants.WdSectionNewPage,
+            "continuous" => ComInteropConstants.WdSectionContinuous,
+            "even-page" or "evenpage" => ComInteropConstants.WdSectionEvenPage,
+            "odd-page" or "oddpage" => ComInteropConstants.WdSectionOddPage,
+            "new-column" or "newcolumn" or "column" => ComInteropConstants.WdSectionNewColumn,
+            _ => throw new ArgumentException(
+                $"Unknown section start '{startType}'. Use one of: next-page, continuous, even-page, "
+                + "odd-page, new-column.",
+                nameof(startType))
+        };
+    }
+
+    /// <summary>
+    /// Converts a <c>WdSectionStart</c> value to its friendly name.
+    /// </summary>
+    /// <param name="wdSectionStart">The Word section start constant.</param>
+    /// <returns>The friendly section start name.</returns>
+    public static string FromWdSectionStart(int wdSectionStart) => wdSectionStart switch
+    {
+        ComInteropConstants.WdSectionContinuous => "continuous",
+        ComInteropConstants.WdSectionNewColumn => "new-column",
+        ComInteropConstants.WdSectionNewPage => "next-page",
+        ComInteropConstants.WdSectionEvenPage => "even-page",
+        ComInteropConstants.WdSectionOddPage => "odd-page",
+        _ => "other"
+    };
+
+    /// <summary>
+    /// Converts a section start name to the <c>WdBreakType</c> used when inserting the break.
+    /// </summary>
+    /// <param name="startType">Same values as <see cref="ToWdSectionStart"/>, except new-column.</param>
+    /// <returns>The Word break type constant.</returns>
+    /// <exception cref="ArgumentException">The section start name is unknown here.</exception>
+    public static int ToWdSectionBreak(string startType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(startType);
+
+        return NormalizeName(startType) switch
+        {
+            "next-page" or "nextpage" or "page" => ComInteropConstants.WdSectionBreakNextPage,
+            "continuous" => ComInteropConstants.WdSectionBreakContinuous,
+            "even-page" or "evenpage" => ComInteropConstants.WdSectionBreakEvenPage,
+            "odd-page" or "oddpage" => ComInteropConstants.WdSectionBreakOddPage,
+            _ => throw new ArgumentException(
+                $"Unknown section break '{startType}'. Use one of: next-page, continuous, even-page, odd-page.",
+                nameof(startType))
+        };
+    }
+
+    /// <summary>
+    /// Converts a header or footer type name to the matching <c>WdHeaderFooterIndex</c> value.
+    /// </summary>
+    /// <param name="type">One of <c>primary</c>, <c>first-page</c> or <c>even-pages</c>.</param>
+    /// <returns>The Word header/footer index constant.</returns>
+    /// <exception cref="ArgumentException">The type name is unknown.</exception>
+    public static int ToWdHeaderFooterIndex(string type)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(type);
+
+        return NormalizeName(type) switch
+        {
+            "primary" or "default" or "main" => ComInteropConstants.WdHeaderFooterPrimary,
+            "first-page" or "firstpage" or "first" => ComInteropConstants.WdHeaderFooterFirstPage,
+            "even-pages" or "evenpages" or "even" => ComInteropConstants.WdHeaderFooterEvenPages,
+            _ => throw new ArgumentException(
+                $"Unknown header/footer type '{type}'. Use one of: primary, first-page, even-pages.",
+                nameof(type))
+        };
+    }
+
+    /// <summary>
+    /// Converts a <c>WdHeaderFooterIndex</c> value to its friendly name.
+    /// </summary>
+    /// <param name="wdHeaderFooterIndex">The Word header/footer index constant.</param>
+    /// <returns>The friendly type name.</returns>
+    public static string FromWdHeaderFooterIndex(int wdHeaderFooterIndex) => wdHeaderFooterIndex switch
+    {
+        ComInteropConstants.WdHeaderFooterPrimary => "primary",
+        ComInteropConstants.WdHeaderFooterFirstPage => "first-page",
+        ComInteropConstants.WdHeaderFooterEvenPages => "even-pages",
+        _ => "other"
+    };
+
+    private static string NormalizeName(string value)
+        => value.Trim().ToLowerInvariant().Replace('_', '-').Replace(" ", string.Empty, StringComparison.Ordinal);
 }

--- a/src/WordMcp.McpServer/Program.cs
+++ b/src/WordMcp.McpServer/Program.cs
@@ -78,7 +78,8 @@ public static class Program
                     SESSION LIFECYCLE:
                     1. file(action:'open', path:'C:\\...\\report.docx') -> returns session_id
                        (or file(action:'create', path:...) for a new document)
-                    2. pass session_id to document / text / paragraph / table / image / field
+                    2. pass session_id to document / text / paragraph / table / image / field /
+                       section / header-footer
                     3. file(action:'close', session_id:..., save:true) when completely done
 
                     Paragraph, table and image indexes are 1-based and shift after structural
@@ -86,6 +87,10 @@ public static class Program
 
                     A table of contents only lists paragraphs that use a heading style, so apply
                     'Heading 1'/'Heading 2' before calling field(insert-toc).
+
+                    Headers and footers belong to sections. Without section_index they apply to
+                    every section; with one, the link to the previous section is broken first.
+                    All measurements are in points (1 cm = 28.35 pt).
                     """;
             })
             .WithToolsFromAssembly()

--- a/src/WordMcp.McpServer/Tools/WordHeaderFooterTool.cs
+++ b/src/WordMcp.McpServer/Tools/WordHeaderFooterTool.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
+
+namespace WordMcp.McpServer.Tools;
+
+/// <summary>Actions of the <c>header-footer</c> tool.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<WordHeaderFooterAction>))]
+public enum WordHeaderFooterAction
+{
+    /// <summary>Read headers or footers.</summary>
+    [JsonStringEnumMemberName("get")] Get,
+
+    /// <summary>Write a header or footer.</summary>
+    [JsonStringEnumMemberName("set")] Set,
+
+    /// <summary>Clear a header or footer.</summary>
+    [JsonStringEnumMemberName("clear")] Clear
+}
+
+/// <summary>
+/// Header and footer operations for an open Word session.
+/// </summary>
+[McpServerToolType]
+public static class WordHeaderFooterTool
+{
+    /// <summary>
+    /// Reads, writes and clears headers and footers.
+    /// </summary>
+    /// <param name="action">The action to perform.</param>
+    /// <param name="session_id">Session identifier from file(open) or file(create).</param>
+    /// <param name="kind">Either <c>header</c> or <c>footer</c>.</param>
+    /// <param name="text">The text to write; required for set.</param>
+    /// <param name="section_index">1-based section; all sections when omitted.</param>
+    /// <param name="type">One of <c>primary</c>, <c>first-page</c> or <c>even-pages</c>.</param>
+    /// <param name="alignment">Optional paragraph alignment for the written text.</param>
+    /// <returns>A JSON payload describing the result.</returns>
+    [McpServerTool(Name = "header-footer", Title = "Header and Footer Operations")]
+    [Description("Header and footer operations on an open document. Headers belong to a SECTION, "
+        + "not to the document, so use section(list) first when a document has more than one. "
+        + "header-footer(set, session_id, kind='footer', text='Confidential') writes the same text "
+        + "to every section; pass section_index to target one. "
+        + "type='first-page' or 'even-pages' switches the matching section option on automatically, "
+        + "because Word otherwise stores the text without ever showing it. "
+        + "Writing to a section whose header is inherited from the previous one breaks that link. "
+        + "header-footer(get, session_id, kind='header') reads the text back. "
+        + "For page numbers use field(insert-page-number) instead, which inserts live fields.")]
+    public static string HeaderFooter(
+        WordHeaderFooterAction action,
+        string session_id,
+        [DefaultValue("header")] string kind = "header",
+        [DefaultValue(null)] string? text = null,
+        [DefaultValue(null)] int? section_index = null,
+        [DefaultValue("primary")] string type = "primary",
+        [DefaultValue(null)] string? alignment = null)
+        => WordToolsBase.Execute("header-footer", action.ToString(), () =>
+        {
+            var batch = WordToolsBase.Batch(session_id);
+
+            return action switch
+            {
+                WordHeaderFooterAction.Get => WordServices.HeadersFooters.Get(
+                    batch, kind, section_index, type),
+                WordHeaderFooterAction.Set => WordServices.HeadersFooters.Set(
+                    batch,
+                    text ?? throw new ArgumentException(
+                        "text is required for header-footer(set).", nameof(text)),
+                    kind,
+                    section_index,
+                    type,
+                    alignment),
+                WordHeaderFooterAction.Clear => WordServices.HeadersFooters.Clear(
+                    batch, kind, section_index, type),
+                _ => throw new ArgumentException($"Unknown action '{action}'.", nameof(action))
+            };
+        });
+}

--- a/src/WordMcp.McpServer/Tools/WordSectionTool.cs
+++ b/src/WordMcp.McpServer/Tools/WordSectionTool.cs
@@ -1,0 +1,84 @@
+using System.ComponentModel;
+using System.Text.Json.Serialization;
+using ModelContextProtocol.Server;
+
+namespace WordMcp.McpServer.Tools;
+
+/// <summary>Actions of the <c>section</c> tool.</summary>
+[JsonConverter(typeof(JsonStringEnumConverter<WordSectionAction>))]
+public enum WordSectionAction
+{
+    /// <summary>List all sections.</summary>
+    [JsonStringEnumMemberName("list")] List,
+
+    /// <summary>Insert a section break.</summary>
+    [JsonStringEnumMemberName("add")] Add,
+
+    /// <summary>Change margins, orientation and paper size.</summary>
+    [JsonStringEnumMemberName("page-setup")] PageSetup
+}
+
+/// <summary>
+/// Section operations for an open Word session.
+/// </summary>
+[McpServerToolType]
+public static class WordSectionTool
+{
+    /// <summary>
+    /// Lists sections, inserts section breaks and changes the page setup.
+    /// </summary>
+    /// <param name="action">The action to perform.</param>
+    /// <param name="session_id">Session identifier from file(open) or file(create).</param>
+    /// <param name="start_type">How a new section starts.</param>
+    /// <param name="paragraph_index">1-based paragraph to insert the break after.</param>
+    /// <param name="section_index">1-based section for page-setup; all sections when omitted.</param>
+    /// <param name="top_margin">Top margin in points.</param>
+    /// <param name="bottom_margin">Bottom margin in points.</param>
+    /// <param name="left_margin">Left margin in points.</param>
+    /// <param name="right_margin">Right margin in points.</param>
+    /// <param name="orientation">Either <c>portrait</c> or <c>landscape</c>.</param>
+    /// <param name="paper_size">A name such as <c>a4</c>, <c>letter</c> or <c>legal</c>.</param>
+    /// <returns>A JSON payload describing the result.</returns>
+    [McpServerTool(Name = "section", Title = "Section Operations")]
+    [Description("Section operations on an open document. A section owns the page setup and the "
+        + "headers and footers, so changing margins or orientation for part of a document means "
+        + "adding a section first. "
+        + "section(list, session_id) returns index, start type, margins, page size and orientation. "
+        + "section(add, session_id, start_type='next-page', paragraph_index=...) inserts a section "
+        + "break after that paragraph, or at the end when omitted. "
+        + "section(page-setup, session_id, section_index=2, orientation='landscape', top_margin=72) "
+        + "changes one section; without section_index it changes the whole document. "
+        + "ALL MEASUREMENTS ARE IN POINTS: 72 pt = 1 inch = 2.54 cm.")]
+    public static string Section(
+        WordSectionAction action,
+        string session_id,
+        [DefaultValue("next-page")] string start_type = "next-page",
+        [DefaultValue(null)] int? paragraph_index = null,
+        [DefaultValue(null)] int? section_index = null,
+        [DefaultValue(null)] double? top_margin = null,
+        [DefaultValue(null)] double? bottom_margin = null,
+        [DefaultValue(null)] double? left_margin = null,
+        [DefaultValue(null)] double? right_margin = null,
+        [DefaultValue(null)] string? orientation = null,
+        [DefaultValue(null)] string? paper_size = null)
+        => WordToolsBase.Execute("section", action.ToString(), () =>
+        {
+            var batch = WordToolsBase.Batch(session_id);
+
+            return action switch
+            {
+                WordSectionAction.List => WordServices.Sections.List(batch),
+                WordSectionAction.Add => WordServices.Sections.Add(batch, start_type, paragraph_index),
+                WordSectionAction.PageSetup => WordServices.Sections.PageSetup(
+                    batch,
+                    section_index,
+                    top_margin,
+                    bottom_margin,
+                    left_margin,
+                    right_margin,
+                    orientation,
+                    paper_size),
+                _ => throw new ArgumentException($"Unknown action '{action}'.", nameof(action))
+            };
+        });
+}

--- a/src/WordMcp.McpServer/WordServices.cs
+++ b/src/WordMcp.McpServer/WordServices.cs
@@ -2,8 +2,10 @@ using Microsoft.Extensions.Logging;
 using WordMcp.ComInterop.Session;
 using WordMcp.Core.Commands.Document;
 using WordMcp.Core.Commands.Field;
+using WordMcp.Core.Commands.HeaderFooter;
 using WordMcp.Core.Commands.Image;
 using WordMcp.Core.Commands.Paragraph;
+using WordMcp.Core.Commands.Section;
 using WordMcp.Core.Commands.Table;
 using WordMcp.Core.Commands.Text;
 
@@ -53,6 +55,12 @@ internal static class WordServices
 
     /// <summary>Gets the field command implementation.</summary>
     public static IFieldCommands Fields { get; } = new FieldCommands();
+
+    /// <summary>Gets the section command implementation.</summary>
+    public static ISectionCommands Sections { get; } = new SectionCommands();
+
+    /// <summary>Gets the header and footer command implementation.</summary>
+    public static IHeaderFooterCommands HeadersFooters { get; } = new HeaderFooterCommands();
 
     /// <summary>
     /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.

--- a/tests/WordMcp.Core.Tests/ImageAndFieldValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/ImageAndFieldValidationTests.cs
@@ -1,6 +1,3 @@
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using WordMcp.ComInterop.Session;
 using WordMcp.Core.Commands.Field;
 using WordMcp.Core.Commands.Image;
 using Xunit;
@@ -122,35 +119,5 @@ public class ImageAndFieldValidationTests
         string path = Path.Combine(Path.GetTempPath(), "wordmcp-" + Guid.NewGuid().ToString("N") + ".png");
         File.WriteAllBytes(path, [0x89, 0x50, 0x4E, 0x47]);
         return path;
-    }
-
-    /// <summary>
-    /// Stands in for a Word batch. Any call means validation let the request through, which is
-    /// exactly what these tests assert.
-    /// </summary>
-    private sealed class ThrowingBatch : IWordBatch
-    {
-        public string DocumentPath => "fake.docx";
-
-        public ILogger Logger => NullLogger.Instance;
-
-        public TimeSpan OperationTimeout => TimeSpan.FromSeconds(30);
-
-        public int? WordProcessId => null;
-
-        public T Execute<T>(Func<WordContext, CancellationToken, T> operation, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Reached the batch.");
-
-        public void Execute(Action<WordContext, CancellationToken> operation, CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Reached the batch.");
-
-        public void Save(CancellationToken cancellationToken = default)
-            => throw new NotSupportedException("Reached the batch.");
-
-        public bool IsWordProcessAlive() => true;
-
-        public void Dispose()
-        {
-        }
     }
 }

--- a/tests/WordMcp.Core.Tests/SectionAndHeaderFooterIntegrationTests.cs
+++ b/tests/WordMcp.Core.Tests/SectionAndHeaderFooterIntegrationTests.cs
@@ -1,0 +1,223 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.HeaderFooter;
+using WordMcp.Core.Commands.Paragraph;
+using WordMcp.Core.Commands.Section;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Integration tests for the section and header/footer commands. They use their own document
+/// because section breaks and page setup changes are document-wide and would break the assertions
+/// of the shared fixture.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class SectionAndHeaderFooterIntegrationTests : IDisposable
+{
+    private static readonly SectionCommands Sections = new();
+    private static readonly HeaderFooterCommands HeadersFooters = new();
+    private static readonly ParagraphCommands Paragraphs = new();
+
+    private readonly SessionManager _sessions = new();
+    private readonly string _directory;
+    private readonly string _sessionId;
+
+    private IWordBatch Batch => _sessions.GetBatch(_sessionId);
+
+    public SectionAndHeaderFooterIntegrationTests()
+    {
+        _directory = Directory
+            .CreateDirectory(Path.Combine(Path.GetTempPath(), "wordmcp-sechf-" + Guid.NewGuid().ToString("N")))
+            .FullName;
+
+        _sessionId = _sessions.Create(Path.Combine(_directory, "sections.docx")).SessionId;
+    }
+
+    [Fact]
+    public void Section_ListReportsSingleSectionForNewDocument()
+    {
+        var list = Sections.List(Batch);
+
+        Assert.Equal(1, list.TotalCount);
+        Assert.Single(list.Sections);
+        Assert.Equal(1, list.Sections[0].Index);
+        Assert.False(list.Sections[0].DifferentFirstPage);
+        Assert.True(list.Sections[0].PageSetup.PageWidth > 0);
+        Assert.Equal("portrait", list.Sections[0].PageSetup.Orientation);
+    }
+
+    [Fact]
+    public void Section_AddCreatesSecondSection()
+    {
+        Paragraphs.Add(Batch, "First section body");
+
+        var added = Sections.Add(Batch, "next-page");
+
+        Assert.Equal(2, added.TotalCount);
+        Assert.Equal("next-page", added.Section.StartType);
+
+        var list = Sections.List(Batch);
+        Assert.Equal(2, list.TotalCount);
+        Assert.Equal([1, 2], list.Sections.Select(s => s.Index));
+    }
+
+    [Fact]
+    public void Section_AddContinuousUsesContinuousStart()
+    {
+        Paragraphs.Add(Batch, "Body");
+
+        var added = Sections.Add(Batch, "continuous");
+
+        Assert.Equal(2, added.TotalCount);
+        Assert.Equal("continuous", added.Section.StartType);
+    }
+
+    [Fact]
+    public void Section_PageSetupAppliesToOneSectionOnly()
+    {
+        Paragraphs.Add(Batch, "Body");
+        Sections.Add(Batch, "next-page");
+
+        var before = Sections.List(Batch).Sections[0].PageSetup;
+
+        var updated = Sections.PageSetup(
+            Batch, sectionIndex: 2, topMargin: 100, bottomMargin: 90, orientation: "landscape");
+
+        Assert.Equal(2, updated.Section.Index);
+        Assert.Equal(100, updated.Section.PageSetup.TopMargin, 1);
+        Assert.Equal(90, updated.Section.PageSetup.BottomMargin, 1);
+        Assert.Equal("landscape", updated.Section.PageSetup.Orientation);
+
+        // Landscape has to swap the page dimensions.
+        Assert.True(updated.Section.PageSetup.PageWidth > updated.Section.PageSetup.PageHeight);
+
+        var after = Sections.List(Batch).Sections[0].PageSetup;
+        Assert.Equal(before.TopMargin, after.TopMargin, 1);
+        Assert.Equal("portrait", after.Orientation);
+    }
+
+    [Fact]
+    public void Section_PageSetupWithoutIndexAppliesToWholeDocument()
+    {
+        Paragraphs.Add(Batch, "Body");
+        Sections.Add(Batch, "next-page");
+
+        Sections.PageSetup(Batch, leftMargin: 120, rightMargin: 120, paperSize: "a4");
+
+        var list = Sections.List(Batch);
+        Assert.Equal(2, list.TotalCount);
+        Assert.All(list.Sections, section =>
+        {
+            Assert.Equal(120, section.PageSetup.LeftMargin, 1);
+            Assert.Equal(120, section.PageSetup.RightMargin, 1);
+        });
+    }
+
+    [Fact]
+    public void Section_PageSetupRejectsMissingSection()
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => Sections.PageSetup(Batch, sectionIndex: 7, topMargin: 72));
+
+    [Fact]
+    public void HeaderFooter_SetGetAndClearHeader()
+    {
+        var set = HeadersFooters.Set(Batch, "Quarterly report", alignment: "center");
+
+        Assert.Equal(1, set.UpdatedCount);
+        Assert.Equal("Quarterly report", set.HeadersFooters[0].Text);
+        Assert.Equal("header", set.HeadersFooters[0].Kind);
+        Assert.Equal("primary", set.HeadersFooters[0].Type);
+        Assert.True(set.HeadersFooters[0].IsActive);
+
+        var read = HeadersFooters.Get(Batch);
+        Assert.Equal("Quarterly report", read.HeadersFooters[0].Text);
+
+        var cleared = HeadersFooters.Clear(Batch);
+        Assert.Equal(string.Empty, cleared.HeadersFooters[0].Text);
+    }
+
+    [Fact]
+    public void HeaderFooter_FooterIsIndependentOfHeader()
+    {
+        HeadersFooters.Set(Batch, "Header text");
+        HeadersFooters.Set(Batch, "Page footer", kind: "footer");
+
+        Assert.Equal("Header text", HeadersFooters.Get(Batch).HeadersFooters[0].Text);
+
+        var footer = HeadersFooters.Get(Batch, kind: "footer");
+        Assert.Equal("Page footer", footer.HeadersFooters[0].Text);
+        Assert.Equal("footer", footer.HeadersFooters[0].Kind);
+    }
+
+    [Fact]
+    public void HeaderFooter_SectionSpecificWriteBreaksTheLink()
+    {
+        Paragraphs.Add(Batch, "Body");
+        Sections.Add(Batch, "next-page");
+
+        HeadersFooters.Set(Batch, "Shared header");
+
+        var both = HeadersFooters.Get(Batch);
+        Assert.Equal(2, both.TotalCount);
+        Assert.All(both.HeadersFooters, entry => Assert.Equal("Shared header", entry.Text));
+
+        var second = HeadersFooters.Set(Batch, "Appendix header", sectionIndex: 2);
+
+        Assert.Equal(1, second.UpdatedCount);
+        Assert.Equal(2, second.HeadersFooters[0].SectionIndex);
+        Assert.False(second.HeadersFooters[0].LinkedToPrevious);
+
+        var after = HeadersFooters.Get(Batch);
+        Assert.Equal("Shared header", after.HeadersFooters[0].Text);
+        Assert.Equal("Appendix header", after.HeadersFooters[1].Text);
+    }
+
+    [Fact]
+    public void HeaderFooter_FirstPageTypeIsActivatedOnWrite()
+    {
+        Assert.False(Sections.List(Batch).Sections[0].DifferentFirstPage);
+
+        var set = HeadersFooters.Set(Batch, "Cover page", type: "first-page");
+
+        Assert.True(set.HeadersFooters[0].IsActive);
+        Assert.Equal("first-page", set.HeadersFooters[0].Type);
+
+        // Writing the first-page header has to flip the section switch, otherwise Word stores the
+        // text but never renders it.
+        Assert.True(Sections.List(Batch).Sections[0].DifferentFirstPage);
+
+        var primary = HeadersFooters.Get(Batch);
+        Assert.Equal(string.Empty, primary.HeadersFooters[0].Text);
+    }
+
+    [Fact]
+    public void HeaderFooter_EvenPagesTypeIsActivatedOnWrite()
+    {
+        HeadersFooters.Set(Batch, "Even footer", kind: "footer", type: "even-pages");
+
+        var list = Sections.List(Batch);
+        Assert.True(list.Sections[0].DifferentOddEvenPages);
+
+        var read = HeadersFooters.Get(Batch, kind: "footer", type: "even-pages");
+        Assert.Equal("Even footer", read.HeadersFooters[0].Text);
+        Assert.True(read.HeadersFooters[0].IsActive);
+    }
+
+    [Fact]
+    public void HeaderFooter_RejectsMissingSection()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => HeadersFooters.Get(Batch, sectionIndex: 9));
+
+    public void Dispose()
+    {
+        _sessions.Dispose();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A locked temp file must not fail the test run.
+        }
+    }
+}

--- a/tests/WordMcp.Core.Tests/SectionAndHeaderFooterValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/SectionAndHeaderFooterValidationTests.cs
@@ -1,0 +1,106 @@
+using WordMcp.Core.Commands.HeaderFooter;
+using WordMcp.Core.Commands.Section;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Argument validation of the section and header/footer commands. All of it runs before the batch
+/// is touched, so these tests need no Word installation and run in CI.
+/// </summary>
+public class SectionAndHeaderFooterValidationTests
+{
+    private static readonly SectionCommands Sections = new();
+    private static readonly HeaderFooterCommands HeadersFooters = new();
+    private static readonly ThrowingBatch Batch = new();
+
+    [Fact]
+    public void Add_RejectsUnknownStartType()
+        => Assert.Throws<ArgumentException>(() => Sections.Add(Batch, "sideways"));
+
+    [Fact]
+    public void Add_RejectsNewColumnAsSectionBreak()
+        => Assert.Throws<ArgumentException>(() => Sections.Add(Batch, "new-column"));
+
+    [Theory]
+    [InlineData("next-page")]
+    [InlineData("continuous")]
+    [InlineData("even-page")]
+    [InlineData("odd-page")]
+    public void Add_AcceptsKnownStartTypes(string startType)
+        => Assert.Throws<NotSupportedException>(() => Sections.Add(Batch, startType));
+
+    [Fact]
+    public void Add_RejectsParagraphIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => Sections.Add(Batch, "next-page", paragraphIndex: 0));
+
+    [Fact]
+    public void PageSetup_RequiresAtLeastOneChange()
+        => Assert.Throws<ArgumentException>(() => Sections.PageSetup(Batch));
+
+    [Fact]
+    public void PageSetup_RejectsNegativeMargins()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Sections.PageSetup(Batch, topMargin: -1));
+
+    [Fact]
+    public void PageSetup_RejectsSectionIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => Sections.PageSetup(Batch, sectionIndex: 0, topMargin: 72));
+
+    [Fact]
+    public void PageSetup_RejectsUnknownOrientation()
+        => Assert.Throws<ArgumentException>(() => Sections.PageSetup(Batch, orientation: "sideways"));
+
+    [Fact]
+    public void PageSetup_RejectsUnknownPaperSize()
+        => Assert.Throws<ArgumentException>(() => Sections.PageSetup(Batch, paperSize: "a2"));
+
+    [Fact]
+    public void PageSetup_ValidatesBeforeWriting()
+    {
+        // A valid request must reach the batch rather than being rejected.
+        Assert.Throws<NotSupportedException>(
+            () => Sections.PageSetup(Batch, topMargin: 72, orientation: "landscape", paperSize: "a4"));
+    }
+
+    [Theory]
+    [InlineData("sideways")]
+    [InlineData(" ")]
+    public void HeaderFooter_RejectsUnknownKind(string kind)
+        => Assert.Throws<ArgumentException>(() => HeadersFooters.Get(Batch, kind));
+
+    [Fact]
+    public void HeaderFooter_RejectsUnknownType()
+        => Assert.Throws<ArgumentException>(() => HeadersFooters.Get(Batch, "header", type: "last-page"));
+
+    [Fact]
+    public void HeaderFooter_RejectsSectionIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(
+            () => HeadersFooters.Get(Batch, "header", sectionIndex: 0));
+
+    [Fact]
+    public void HeaderFooter_RejectsNullTextOnSet()
+        => Assert.Throws<ArgumentNullException>(() => HeadersFooters.Set(Batch, null!));
+
+    [Fact]
+    public void HeaderFooter_RejectsUnknownAlignment()
+        => Assert.Throws<ArgumentException>(
+            () => HeadersFooters.Set(Batch, "text", alignment: "diagonal"));
+
+    [Theory]
+    [InlineData("header", "primary")]
+    [InlineData("footer", "first-page")]
+    [InlineData("header", "even-pages")]
+    public void HeaderFooter_AcceptsKnownCombinations(string kind, string type)
+        => Assert.Throws<NotSupportedException>(() => HeadersFooters.Set(Batch, "text", kind, type: type));
+
+    [Fact]
+    public void Commands_RejectNullBatch()
+    {
+        Assert.Throws<ArgumentNullException>(() => Sections.List(null!));
+        Assert.Throws<ArgumentNullException>(() => HeadersFooters.Get(null!));
+        Assert.Throws<ArgumentNullException>(() => HeadersFooters.Set(null!, "text"));
+        Assert.Throws<ArgumentNullException>(() => HeadersFooters.Clear(null!));
+    }
+}

--- a/tests/WordMcp.Core.Tests/ThrowingBatch.cs
+++ b/tests/WordMcp.Core.Tests/ThrowingBatch.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using WordMcp.ComInterop.Session;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Stands in for a Word batch in validation tests. Any call means the argument checks let the
+/// request through, which is what those tests assert.
+/// </summary>
+internal sealed class ThrowingBatch : IWordBatch
+{
+    public string DocumentPath => "fake.docx";
+
+    public ILogger Logger => NullLogger.Instance;
+
+    public TimeSpan OperationTimeout => TimeSpan.FromSeconds(30);
+
+    public int? WordProcessId => null;
+
+    public T Execute<T>(Func<WordContext, CancellationToken, T> operation, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Reached the batch.");
+
+    public void Execute(Action<WordContext, CancellationToken> operation, CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Reached the batch.");
+
+    public void Save(CancellationToken cancellationToken = default)
+        => throw new NotSupportedException("Reached the batch.");
+
+    public bool IsWordProcessAlive() => true;
+
+    public void Dispose()
+    {
+    }
+}

--- a/tests/WordMcp.Core.Tests/WordConversionsSectionTests.cs
+++ b/tests/WordMcp.Core.Tests/WordConversionsSectionTests.cs
@@ -1,0 +1,105 @@
+using WordMcp.Core.Utilities;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Conversions introduced for the section and header/footer tools.
+/// </summary>
+public class WordConversionsSectionTests
+{
+    [Theory]
+    [InlineData("portrait", 0)]
+    [InlineData("Portrait", 0)]
+    [InlineData("landscape", 1)]
+    [InlineData("horizontal", 1)]
+    public void ToWdOrientation_MapsKnownNames(string name, int expected)
+        => Assert.Equal(expected, WordConversions.ToWdOrientation(name));
+
+    [Theory]
+    [InlineData("diagonal")]
+    [InlineData(" ")]
+    public void ToWdOrientation_RejectsUnknownNames(string name)
+        => Assert.Throws<ArgumentException>(() => WordConversions.ToWdOrientation(name));
+
+    [Fact]
+    public void FromWdOrientation_RoundTrips()
+    {
+        Assert.Equal("portrait", WordConversions.FromWdOrientation(0));
+        Assert.Equal("landscape", WordConversions.FromWdOrientation(1));
+        Assert.Equal("other", WordConversions.FromWdOrientation(99));
+    }
+
+    [Theory]
+    [InlineData("a4", 7)]
+    [InlineData("A4", 7)]
+    [InlineData("letter", 2)]
+    [InlineData("legal", 5)]
+    [InlineData("tabloid", 16)]
+    public void ToWdPaperSize_MapsKnownNames(string name, int expected)
+        => Assert.Equal(expected, WordConversions.ToWdPaperSize(name));
+
+    [Fact]
+    public void ToWdPaperSize_RejectsUnknownNames()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => WordConversions.ToWdPaperSize("a2"));
+        Assert.Contains("a4", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("next-page", 2)]
+    [InlineData("next_page", 2)]
+    [InlineData("continuous", 0)]
+    [InlineData("even-page", 3)]
+    [InlineData("odd-page", 4)]
+    [InlineData("new-column", 1)]
+    public void ToWdSectionStart_MapsKnownNames(string name, int expected)
+        => Assert.Equal(expected, WordConversions.ToWdSectionStart(name));
+
+    [Theory]
+    [InlineData("next-page", 2)]
+    [InlineData("continuous", 3)]
+    [InlineData("even-page", 4)]
+    [InlineData("odd-page", 5)]
+    public void ToWdSectionBreak_MapsKnownNames(string name, int expected)
+        => Assert.Equal(expected, WordConversions.ToWdSectionBreak(name));
+
+    [Fact]
+    public void ToWdSectionBreak_RejectsNewColumn()
+    {
+        // A new column is a section start but not a section break type.
+        Assert.Throws<ArgumentException>(() => WordConversions.ToWdSectionBreak("new-column"));
+    }
+
+    [Fact]
+    public void FromWdSectionStart_RoundTrips()
+    {
+        foreach (string name in new[] { "next-page", "continuous", "even-page", "odd-page", "new-column" })
+        {
+            Assert.Equal(name, WordConversions.FromWdSectionStart(WordConversions.ToWdSectionStart(name)));
+        }
+    }
+
+    [Theory]
+    [InlineData("primary", 1)]
+    [InlineData("default", 1)]
+    [InlineData("first-page", 2)]
+    [InlineData("first_page", 2)]
+    [InlineData("even-pages", 3)]
+    public void ToWdHeaderFooterIndex_MapsKnownNames(string name, int expected)
+        => Assert.Equal(expected, WordConversions.ToWdHeaderFooterIndex(name));
+
+    [Fact]
+    public void ToWdHeaderFooterIndex_RejectsUnknownNames()
+        => Assert.Throws<ArgumentException>(() => WordConversions.ToWdHeaderFooterIndex("last-page"));
+
+    [Fact]
+    public void FromWdHeaderFooterIndex_RoundTrips()
+    {
+        foreach (string name in new[] { "primary", "first-page", "even-pages" })
+        {
+            Assert.Equal(name, WordConversions.FromWdHeaderFooterIndex(
+                WordConversions.ToWdHeaderFooterIndex(name)));
+        }
+    }
+}

--- a/tests/WordMcp.McpServer.Tests/WordToolContractTests.cs
+++ b/tests/WordMcp.McpServer.Tests/WordToolContractTests.cs
@@ -14,7 +14,9 @@ public class WordToolContractTests
     public static TheoryData<Type> ActionEnums =>
     [
         typeof(WordImageAction),
-        typeof(WordFieldAction)
+        typeof(WordFieldAction),
+        typeof(WordSectionAction),
+        typeof(WordHeaderFooterAction)
     ];
 
     [Theory]


### PR DESCRIPTION
Adds the `section` and `header-footer` tools. They ship together because a header lives on a section — you cannot meaningfully test one without the other.

Closes #19
Closes #20

## `section`

| Action | Purpose |
|---|---|
| `list` | Sections with start type, margins, page size, orientation |
| `add` | Section break (`next-page`, `continuous`, `even-page`, `odd-page`) |
| `page-setup` | Margins, orientation, paper size — one section or the whole document |

## `header-footer`

| Action | Purpose |
|---|---|
| `get` | Read one section's or all sections' header/footer |
| `set` | Write text, optionally aligned |
| `clear` | Empty it |

`kind` is `header`/`footer`, `type` is `primary`/`first-page`/`even-pages`.

## Word behaviour handled here

* **Paper size resets the margins**, so `page-setup` applies it before them.
* **Headers are inherited between sections.** A new section shows the previous one's header until something is written. Writing with a `section_index` breaks `LinkToPrevious` first — otherwise the write lands on the previous section too.
* **`first-page`/`even-pages` need a section switch.** Writing one turns on `DifferentFirstPage` / `DifferentOddEvenPages`, otherwise Word stores the text and never renders it.
* **All measurements are in points**, consistent with the `image` tool. Values are rounded to two decimals because Word returns single-precision floats (`56.70000076`).

## Tests

229 total, all green: 12 new integration tests against real Word, plus conversion and validation tests that need no Word installation and run in CI. The `ThrowingBatch` fake moved to its own file so both validation suites share it.

README documents both tools, the point-based measurements and the three pitfalls above.