### PR TITLE
Add style tool for listing and editing document styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ file(open|create) ──► session_id ──► text / paragraph / table / docu
 
 ## Tools
 
-Nine tools, each with an `action` parameter.
+Ten tools, each with an `action` parameter.
 
 ### `file` — session lifecycle
 
@@ -189,6 +189,24 @@ Paragraph indices are **1-based**, matching Word.
 
 `kind` selects `header` or `footer`, `type` selects `primary`, `first-page` or `even-pages`.
 
+### `style` — styles
+
+| Action | Purpose |
+|---|---|
+| `list` | List styles; by default only the ones the document uses |
+| `create` | Add a custom style, optionally based on an existing one |
+| `modify` | Change font and paragraph formatting of a style |
+| `delete` | Remove a custom style |
+
+`style_type` selects `paragraph`, `character`, `table` or `list`. Pass `in_use_only: false` to
+`list` for the full set, which is over 370 entries on a localized Word.
+
+```jsonc
+style(action: "create", session_id: "...", name: "Callout", base_style: "Normal")
+style(action: "modify", session_id: "...", name: "Callout",
+      font_size: 11, bold: true, color: "#C00000", space_after: 12)
+```
+
 ---
 
 ## Responses
@@ -215,7 +233,8 @@ Every tool returns JSON. Failures are reported as structured payloads, never as 
 * **Rights-protected documents** (IRM/AIP) are rejected before Word is launched.
 * **A document open in Word blocks the session** — close it first.
 * **Word dialogs stall automation.** If a call times out, check for an open dialog on the desktop.
-* **Style names are English.** Built-in styles (`Heading 1`, `Title`, `Table Grid`, …) are translated to Word's language-independent style ids, so they work on localized installations. Any other name is passed to Word as-is, which is how custom and localized styles are addressed. Note that Word *reports* styles under their localized name (`Überschrift 1` on a German install).
+* **Style names are English.** Built-in styles (`Heading 1`, `Title`, `Table Grid`, …) are translated to Word's language-independent style ids, so they work on localized installations. Any other name is passed to Word as-is, which is how custom and localized styles are addressed. Note that Word *reports* styles under their localized name (`Überschrift 1` on a German install), which is why `style(list)` returns both `name` and `english_name` — send `english_name` back when it is present.
+* **Built-in styles cannot be deleted.** `style(delete)` rejects them with a clear message instead of passing Word's generic COM error through. A custom style that is still applied to a paragraph cannot be deleted either; set those paragraphs to another style first.
 * **New documents are written directly, not via Word.** `file(create)` writes an empty `.docx`/`.docm` package itself and then opens it. Creating documents through Word instead is unreliable on machines signed in to Microsoft 365, because AutoSave claims the new document for OneDrive and silently ignores the requested local path.
 * **Merged table cells** are returned as empty strings by `table(read)`.
 * **Image sizes are in points, not pixels** (72 pt = 1 inch). `image(insert)` and `image(resize)` keep the aspect ratio unless `lock_aspect_ratio` is set to `false`, so passing only `width` scales the height along with it.
@@ -247,13 +266,13 @@ dotnet test WordMcp.sln --filter "Category!=RequiresWord"
 | `src/WordMcp.Core` | Command interfaces, command implementations and result models |
 | `src/WordMcp.Generators.Shared` | Source files shared by the generators; not a project of its own |
 | `src/WordMcp.Generators.Mcp` | Roslyn source generator that emits the MCP tool classes |
-| `src/WordMcp.McpServer` | stdio MCP server exposing the nine tools |
+| `src/WordMcp.McpServer` | stdio MCP server exposing the ten tools |
 | `tests/WordMcp.Core.Tests` | Unit tests plus integration tests against a real Word |
 | `tests/WordMcp.McpServer.Tests` | Tool-layer unit tests, no Word required |
 
 ### Generated tool layer
 
-Eight of the nine tools are generated at build time. The command interfaces in
+Nine of the ten tools are generated at build time. The command interfaces in
 `src/WordMcp.Core/Commands` are the single source of truth for the wire contract:
 
 - `[ServiceCategory("section", "Section")]` names the tool class, `WordSectionTool`.

--- a/src/WordMcp.ComInterop/ComInteropConstants.cs
+++ b/src/WordMcp.ComInterop/ComInteropConstants.cs
@@ -200,6 +200,25 @@ public static class ComInteropConstants
 
     #endregion
 
+    #region Styles
+
+    /// <summary>WdStyleType.wdStyleTypeParagraph = 1.</summary>
+    public const int WdStyleTypeParagraph = 1;
+
+    /// <summary>WdStyleType.wdStyleTypeCharacter = 2.</summary>
+    public const int WdStyleTypeCharacter = 2;
+
+    /// <summary>WdStyleType.wdStyleTypeTable = 3.</summary>
+    public const int WdStyleTypeTable = 3;
+
+    /// <summary>WdStyleType.wdStyleTypeList = 4.</summary>
+    public const int WdStyleTypeList = 4;
+
+    /// <summary>WdLineSpacing.wdLineSpaceExactly = 4, used when line spacing is given in points.</summary>
+    public const int WdLineSpaceExactly = 4;
+
+    #endregion
+
     #region Supported extensions
 
     /// <summary>

--- a/src/WordMcp.Core/Commands/Style/IStyleCommands.cs
+++ b/src/WordMcp.Core/Commands/Style/IStyleCommands.cs
@@ -1,0 +1,95 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Style;
+
+/// <summary>
+/// Style operations: listing, creating, modifying and deleting styles.
+/// </summary>
+[ServiceCategory("style", "Style")]
+[McpTool("style",
+    Title = "Style Operations",
+    Description = "Style operations on an open document. Styles keep formatting consistent "
+        + "without touching every piece of text. "
+        + "style(list, session_id) returns only the styles the document actually uses; pass "
+        + "in_use_only=false for the complete list, which is over 370 entries on a localized Word. "
+        + "style(create, session_id, name='Callout', style_type='paragraph', base_style='Normal') "
+        + "adds a custom style. "
+        + "style(modify, session_id, name='Callout', font_name='Calibri', font_size=11, bold=true, "
+        + "color='#C00000', alignment='center', space_after=12) changes formatting; omitted "
+        + "properties stay as they are. "
+        + "style(delete, session_id, name='Callout') removes a custom style; built-in styles "
+        + "cannot be deleted. "
+        + "LOCALIZED NAMES: Word reports styles under localized names, so a German Word calls "
+        + "'Heading 1' 'Ueberschrift 1'. Built-in styles are addressable by their English name; "
+        + "list returns both, and english_name is the one to send back. "
+        + "Sizes and spacing are in points (72 pt = 1 inch).")]
+public interface IStyleCommands
+{
+    /// <summary>
+    /// Lists the styles of the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="inUseOnly">
+    /// Whether to return only styles applied or modified in the document. Defaults to true,
+    /// because a localized Word defines several hundred styles that are never used.
+    /// </param>
+    /// <param name="styleType">
+    /// Restrict the result to one kind: paragraph, character, table or list. All kinds when omitted.
+    /// </param>
+    /// <returns>The matching styles.</returns>
+    [ServiceAction("list")]
+    StyleListResult List(IWordBatch batch, bool inUseOnly = true, string? styleType = null);
+
+    /// <summary>
+    /// Creates a custom style.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="name">Name of the new style; it must not exist yet.</param>
+    /// <param name="styleType">Kind of style: paragraph, character, table or list. Defaults to paragraph.</param>
+    /// <param name="baseStyle">Style to inherit from, for example <c>Normal</c>.</param>
+    /// <returns>The created style.</returns>
+    [ServiceAction("create")]
+    StyleResult Create(IWordBatch batch, string name, string styleType = "paragraph", string? baseStyle = null);
+
+    /// <summary>
+    /// Changes the formatting of a style. Only the properties supplied are written.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="name">Name of the style to change; English names work for built-in styles.</param>
+    /// <param name="fontName">New font name.</param>
+    /// <param name="fontSize">New font size in points.</param>
+    /// <param name="bold">Whether the style is bold.</param>
+    /// <param name="italic">Whether the style is italic.</param>
+    /// <param name="underline">Whether the style is underlined.</param>
+    /// <param name="color">Font colour as a hex value such as <c>#C00000</c>.</param>
+    /// <param name="alignment">Paragraph alignment: left, center, right or justify.</param>
+    /// <param name="spaceBefore">Space above a paragraph in points.</param>
+    /// <param name="spaceAfter">Space below a paragraph in points.</param>
+    /// <param name="lineSpacing">Line spacing in points.</param>
+    /// <returns>The style after the change.</returns>
+    [ServiceAction("modify")]
+    StyleResult Modify(
+        IWordBatch batch,
+        string name,
+        string? fontName = null,
+        double? fontSize = null,
+        bool? bold = null,
+        bool? italic = null,
+        bool? underline = null,
+        string? color = null,
+        string? alignment = null,
+        double? spaceBefore = null,
+        double? spaceAfter = null,
+        double? lineSpacing = null);
+
+    /// <summary>
+    /// Deletes a custom style. Built-in styles are rejected, because Word cannot remove them.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="name">Name of the style to delete.</param>
+    /// <returns>The result of the operation.</returns>
+    [ServiceAction("delete")]
+    StyleResult Delete(IWordBatch batch, string name);
+}

--- a/src/WordMcp.Core/Commands/Style/StyleCommands.cs
+++ b/src/WordMcp.Core/Commands/Style/StyleCommands.cs
@@ -1,0 +1,336 @@
+using System.Runtime.InteropServices;
+using WordMcp.ComInterop;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.Style;
+
+/// <summary>
+/// Word COM implementation of <see cref="IStyleCommands"/>.
+/// </summary>
+public sealed class StyleCommands : IStyleCommands
+{
+    /// <inheritdoc />
+    public StyleListResult List(IWordBatch batch, bool inUseOnly = true, string? styleType = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        int? wantedType = styleType is null ? null : WordConversions.ToWdStyleType(styleType);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic styles = doc.Styles;
+            int total = (int)styles.Count;
+
+            var englishNames = MapLocalNamesToEnglish(doc);
+            var list = new List<StyleInfo>();
+
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                dynamic style = styles[i];
+
+                int type = (int)style.Type;
+                if (wantedType.HasValue && type != wantedType.Value)
+                    continue;
+
+                // Word's InUse also covers built-in styles that were merely modified, which is
+                // exactly the set a caller cares about when formatting a document.
+                bool inUse = (bool)style.InUse;
+                if (inUseOnly && !inUse)
+                    continue;
+
+                list.Add(Describe(style, englishNames));
+            }
+
+            return new StyleListResult
+            {
+                TotalCount = total,
+                ReturnedCount = list.Count,
+                Styles = list
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public StyleResult Create(IWordBatch batch, string name, string styleType = "paragraph", string? baseStyle = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        int wdStyleType = WordConversions.ToWdStyleType(styleType);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+
+            if (Find(doc, name) != null)
+            {
+                throw new ArgumentException(
+                    $"Style '{name}' already exists. Use style(action:'modify') to change it.", nameof(name));
+            }
+
+            dynamic style = doc.Styles.Add(name, wdStyleType);
+
+            if (!string.IsNullOrWhiteSpace(baseStyle))
+            {
+                try
+                {
+                    style.BaseStyle = WordStyles.Resolve(baseStyle);
+                }
+                catch (COMException ex)
+                {
+                    throw new ArgumentException(
+                        $"Base style '{baseStyle}' does not exist in this document.", nameof(baseStyle), ex);
+                }
+            }
+
+            return new StyleResult
+            {
+                Style = Describe(style, MapLocalNamesToEnglish(doc)),
+                Message = $"Style '{name}' created."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public StyleResult Modify(
+        IWordBatch batch,
+        string name,
+        string? fontName = null,
+        double? fontSize = null,
+        bool? bold = null,
+        bool? italic = null,
+        bool? underline = null,
+        string? color = null,
+        string? alignment = null,
+        double? spaceBefore = null,
+        double? spaceAfter = null,
+        double? lineSpacing = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        if (fontSize is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(fontSize), "font_size must be greater than 0.");
+        }
+
+        if (lineSpacing is <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(lineSpacing), "line_spacing must be greater than 0.");
+        }
+
+        // Converting up front turns a bad value into a clear error before Word is involved.
+        int? wdColor = color is null ? null : WordConversions.ToWdColor(color);
+        int? wdAlignment = alignment is null ? null : WordConversions.ToWdAlignment(alignment);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic style = Find(doc, name)
+                ?? throw new ArgumentException($"Style '{name}' does not exist in this document.", nameof(name));
+
+            ApplyFont(style, fontName, fontSize, bold, italic, underline, wdColor);
+            ApplyParagraphFormat(style, wdAlignment, spaceBefore, spaceAfter, lineSpacing);
+
+            return new StyleResult
+            {
+                Style = Describe(style, MapLocalNamesToEnglish(doc)),
+                Message = $"Style '{name}' modified."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public StyleResult Delete(IWordBatch batch, string name)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic style = Find(doc, name)
+                ?? throw new ArgumentException($"Style '{name}' does not exist in this document.", nameof(name));
+
+            // Word raises a generic COM error for this, so the check produces a usable message.
+            if ((bool)style.BuiltIn)
+            {
+                throw new InvalidOperationException(
+                    $"Style '{name}' is built into Word and cannot be deleted. Only custom styles can.");
+            }
+
+            style.Delete();
+
+            return new StyleResult { Message = $"Style '{name}' deleted." };
+        });
+    }
+
+    private static void ApplyFont(
+        dynamic style,
+        string? fontName,
+        double? fontSize,
+        bool? bold,
+        bool? italic,
+        bool? underline,
+        int? wdColor)
+    {
+        if (fontName is null && fontSize is null && bold is null
+            && italic is null && underline is null && wdColor is null)
+        {
+            return;
+        }
+
+        dynamic font = style.Font;
+
+        if (!string.IsNullOrWhiteSpace(fontName))
+            font.Name = fontName;
+
+        if (fontSize.HasValue)
+            font.Size = (float)fontSize.Value;
+
+        // Word's font flags are tri-state integers, so a plain bool would not round-trip.
+        if (bold.HasValue)
+            font.Bold = bold.Value ? ComInteropConstants.MsoTrue : ComInteropConstants.MsoFalse;
+
+        if (italic.HasValue)
+            font.Italic = italic.Value ? ComInteropConstants.MsoTrue : ComInteropConstants.MsoFalse;
+
+        if (underline.HasValue)
+            font.Underline = underline.Value ? ComInteropConstants.MsoTrue : ComInteropConstants.MsoFalse;
+
+        if (wdColor.HasValue)
+            font.Color = wdColor.Value;
+    }
+
+    private static void ApplyParagraphFormat(
+        dynamic style,
+        int? wdAlignment,
+        double? spaceBefore,
+        double? spaceAfter,
+        double? lineSpacing)
+    {
+        if (wdAlignment is null && spaceBefore is null && spaceAfter is null && lineSpacing is null)
+        {
+            return;
+        }
+
+        dynamic format;
+        try
+        {
+            format = style.ParagraphFormat;
+        }
+        catch (COMException ex)
+        {
+            throw new ArgumentException(
+                "Paragraph formatting can only be set on paragraph and table styles.", nameof(style), ex);
+        }
+
+        if (wdAlignment.HasValue)
+            format.Alignment = wdAlignment.Value;
+
+        if (spaceBefore.HasValue)
+            format.SpaceBefore = (float)spaceBefore.Value;
+
+        if (spaceAfter.HasValue)
+            format.SpaceAfter = (float)spaceAfter.Value;
+
+        if (lineSpacing.HasValue)
+        {
+            // LineSpacing is only honoured once the rule says the value is an exact measurement.
+            format.LineSpacingRule = ComInteropConstants.WdLineSpaceExactly;
+            format.LineSpacing = (float)lineSpacing.Value;
+        }
+    }
+
+    /// <summary>
+    /// Looks a style up by name, accepting the English name of a built-in style on a localized Word.
+    /// </summary>
+    private static dynamic? Find(dynamic doc, string name)
+    {
+        try
+        {
+            return doc.Styles[WordStyles.Resolve(name)];
+        }
+        catch (COMException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Builds the reverse of <see cref="WordStyles"/>: the name Word reports mapped to the English
+    /// name a client can send back on any language version.
+    /// </summary>
+    private static Dictionary<string, string> MapLocalNamesToEnglish(dynamic doc)
+    {
+        var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in WordStyles.KnownBuiltInStyles)
+        {
+            try
+            {
+                dynamic style = doc.Styles[entry.Value];
+                map[(string)style.NameLocal] = entry.Key;
+            }
+            catch (COMException)
+            {
+                // Not every built-in style exists in every template; skipping one only costs the
+                // English name of that single style.
+            }
+        }
+
+        return map;
+    }
+
+    private static StyleInfo Describe(dynamic style, Dictionary<string, string> englishNames)
+    {
+        string name = (string)style.NameLocal;
+        int type = (int)style.Type;
+
+        var info = new StyleInfo
+        {
+            Name = name,
+            EnglishName = englishNames.TryGetValue(name, out string? english) ? english : null,
+            Type = WordConversions.FromWdStyleType(type),
+            BuiltIn = (bool)style.BuiltIn,
+            InUse = (bool)style.InUse,
+            BaseStyle = ReadBaseStyle(style)
+        };
+
+        if (type is ComInteropConstants.WdStyleTypeParagraph or ComInteropConstants.WdStyleTypeCharacter)
+        {
+            try
+            {
+                dynamic font = style.Font;
+                info.FontName = (string)font.Name;
+                info.FontSize = (double)(float)font.Size;
+            }
+            catch (COMException)
+            {
+                // A style can inherit its font entirely, in which case Word refuses to report one.
+            }
+        }
+
+        return info;
+    }
+
+    private static string? ReadBaseStyle(dynamic style)
+    {
+        try
+        {
+            dynamic baseStyle = style.BaseStyle;
+            string name = (string)baseStyle.NameLocal;
+            return string.IsNullOrWhiteSpace(name) ? null : name;
+        }
+        catch (COMException)
+        {
+            // Styles without a base, such as Normal, throw instead of returning nothing.
+            return null;
+        }
+    }
+}

--- a/src/WordMcp.Core/Models/StyleResults.cs
+++ b/src/WordMcp.Core/Models/StyleResults.cs
@@ -1,0 +1,62 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Metadata for a single style of a document.
+/// </summary>
+public sealed class StyleInfo
+{
+    /// <summary>
+    /// Gets or sets the name Word reports, which is localized on a non-English installation.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the English name of a built-in style, which is what clients should pass back.
+    /// Empty for custom styles, whose name is already language independent.
+    /// </summary>
+    public string? EnglishName { get; set; }
+
+    /// <summary>
+    /// Gets or sets the kind of style: <c>paragraph</c>, <c>character</c>, <c>table</c> or <c>list</c>.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets whether Word ships the style.</summary>
+    public bool BuiltIn { get; set; }
+
+    /// <summary>Gets or sets whether the style is applied or modified in this document.</summary>
+    public bool InUse { get; set; }
+
+    /// <summary>Gets or sets the style this one inherits from, when there is one.</summary>
+    public string? BaseStyle { get; set; }
+
+    /// <summary>Gets or sets the font name, for paragraph and character styles.</summary>
+    public string? FontName { get; set; }
+
+    /// <summary>Gets or sets the font size in points, for paragraph and character styles.</summary>
+    public double? FontSize { get; set; }
+}
+
+/// <summary>
+/// The styles of a document.
+/// </summary>
+public sealed class StyleListResult : ResultBase
+{
+    /// <summary>Gets or sets the number of styles the document defines.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets the number of styles returned after filtering.</summary>
+    public int ReturnedCount { get; set; }
+
+    /// <summary>Gets or sets the styles.</summary>
+    public IReadOnlyList<StyleInfo> Styles { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation that creates, changes or removes a style.
+/// </summary>
+public sealed class StyleResult : ResultBase
+{
+    /// <summary>Gets or sets the affected style, when it still exists.</summary>
+    public StyleInfo? Style { get; set; }
+}

--- a/src/WordMcp.Core/Utilities/WordConversions.cs
+++ b/src/WordMcp.Core/Utilities/WordConversions.cs
@@ -257,6 +257,42 @@ public static class WordConversions
         _ => "other"
     };
 
+    /// <summary>
+    /// Converts a style kind name to the matching <c>WdStyleType</c> value.
+    /// </summary>
+    /// <param name="styleType">One of <c>paragraph</c>, <c>character</c>, <c>table</c> or <c>list</c>.</param>
+    /// <returns>The Word style type constant.</returns>
+    /// <exception cref="ArgumentException">The style kind is unknown.</exception>
+    public static int ToWdStyleType(string styleType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(styleType);
+
+        return NormalizeName(styleType) switch
+        {
+            "paragraph" => ComInteropConstants.WdStyleTypeParagraph,
+            "character" => ComInteropConstants.WdStyleTypeCharacter,
+            "table" => ComInteropConstants.WdStyleTypeTable,
+            "list" => ComInteropConstants.WdStyleTypeList,
+            _ => throw new ArgumentException(
+                $"Unknown style type '{styleType}'. Use one of: paragraph, character, table, list.",
+                nameof(styleType))
+        };
+    }
+
+    /// <summary>
+    /// Converts a <c>WdStyleType</c> value to its friendly name.
+    /// </summary>
+    /// <param name="wdStyleType">The Word style type constant.</param>
+    /// <returns>The friendly style kind name.</returns>
+    public static string FromWdStyleType(int wdStyleType) => wdStyleType switch
+    {
+        ComInteropConstants.WdStyleTypeParagraph => "paragraph",
+        ComInteropConstants.WdStyleTypeCharacter => "character",
+        ComInteropConstants.WdStyleTypeTable => "table",
+        ComInteropConstants.WdStyleTypeList => "list",
+        _ => "other"
+    };
+
     private static string NormalizeName(string value)
         => value.Trim().ToLowerInvariant().Replace('_', '-').Replace(" ", string.Empty, StringComparison.Ordinal);
 }

--- a/src/WordMcp.Core/Utilities/WordStyles.cs
+++ b/src/WordMcp.Core/Utilities/WordStyles.cs
@@ -41,6 +41,15 @@ public static class WordStyles
         };
 
     /// <summary>
+    /// Gets the English built-in style names and their <c>WdBuiltinStyle</c> constants.
+    /// </summary>
+    /// <remarks>
+    /// Useful to map back from a localized name: asking Word for each constant yields the local
+    /// name, which pairs it with the English name a client should send.
+    /// </remarks>
+    public static IReadOnlyDictionary<string, int> KnownBuiltInStyles => BuiltInStyles;
+
+    /// <summary>
     /// Converts a style name into the value to assign to a Word <c>Style</c> property.
     /// </summary>
     /// <param name="styleName">Style name as supplied by the caller.</param>

--- a/src/WordMcp.McpServer/WordServices.cs
+++ b/src/WordMcp.McpServer/WordServices.cs
@@ -6,6 +6,7 @@ using WordMcp.Core.Commands.HeaderFooter;
 using WordMcp.Core.Commands.Image;
 using WordMcp.Core.Commands.Paragraph;
 using WordMcp.Core.Commands.Section;
+using WordMcp.Core.Commands.Style;
 using WordMcp.Core.Commands.Table;
 using WordMcp.Core.Commands.Text;
 
@@ -61,6 +62,9 @@ internal static class WordServices
 
     /// <summary>Gets the header and footer command implementation.</summary>
     public static IHeaderFooterCommands HeadersFooters { get; } = new HeaderFooterCommands();
+
+    /// <summary>Gets the style command implementation.</summary>
+    public static IStyleCommands Styles { get; } = new StyleCommands();
 
     /// <summary>
     /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.

--- a/tests/WordMcp.Core.Tests/StyleIntegrationTests.cs
+++ b/tests/WordMcp.Core.Tests/StyleIntegrationTests.cs
@@ -1,0 +1,148 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.Paragraph;
+using WordMcp.Core.Commands.Style;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Integration tests for the style commands. They use their own document because creating and
+/// deleting styles changes the document-wide style collection.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class StyleIntegrationTests : IDisposable
+{
+    private static readonly StyleCommands Styles = new();
+    private static readonly ParagraphCommands Paragraphs = new();
+
+    private readonly SessionManager _sessions = new();
+    private readonly string _directory;
+    private readonly string _sessionId;
+
+    private IWordBatch Batch => _sessions.GetBatch(_sessionId);
+
+    public StyleIntegrationTests()
+    {
+        _directory = Directory
+            .CreateDirectory(Path.Combine(Path.GetTempPath(), "wordmcp-style-" + Guid.NewGuid().ToString("N")))
+            .FullName;
+
+        _sessionId = _sessions.Create(Path.Combine(_directory, "styles.docx")).SessionId;
+    }
+
+    [Fact]
+    public void Style_ListReportsFewerStylesWhenFilteringByUse()
+    {
+        var used = Styles.List(Batch);
+        var all = Styles.List(Batch, inUseOnly: false);
+
+        Assert.Equal(all.TotalCount, used.TotalCount);
+        Assert.True(all.ReturnedCount > used.ReturnedCount);
+        Assert.Equal(all.ReturnedCount, all.Styles.Count);
+        Assert.All(used.Styles, style => Assert.True(style.InUse));
+    }
+
+    [Fact]
+    public void Style_ListReportsEnglishNamesForBuiltInStyles()
+    {
+        var all = Styles.List(Batch, inUseOnly: false);
+
+        var heading = Assert.Single(all.Styles, s => s.EnglishName == "Heading 1");
+
+        Assert.True(heading.BuiltIn);
+        Assert.Equal("paragraph", heading.Type);
+        Assert.False(string.IsNullOrWhiteSpace(heading.Name));
+    }
+
+    [Fact]
+    public void Style_ListFiltersByStyleType()
+    {
+        var characters = Styles.List(Batch, inUseOnly: false, styleType: "character");
+
+        Assert.NotEmpty(characters.Styles);
+        Assert.All(characters.Styles, style => Assert.Equal("character", style.Type));
+    }
+
+    [Fact]
+    public void Style_CreateModifyApplyDeleteRoundTrip()
+    {
+        var created = Styles.Create(Batch, "Callout", "paragraph", "Normal");
+
+        Assert.NotNull(created.Style);
+        Assert.Equal("Callout", created.Style!.Name);
+        Assert.False(created.Style.BuiltIn);
+        Assert.Equal("paragraph", created.Style.Type);
+
+        var modified = Styles.Modify(
+            Batch,
+            "Callout",
+            fontName: "Calibri",
+            fontSize: 14,
+            bold: true,
+            color: "#C00000",
+            alignment: "center",
+            spaceAfter: 12);
+
+        Assert.Equal("Calibri", modified.Style!.FontName);
+        Assert.Equal(14, modified.Style.FontSize);
+
+        // Applying the style is the real proof that Word accepted it as a usable paragraph style.
+        Paragraphs.Add(Batch, "Important note", style: "Callout");
+
+        var inUse = Styles.List(Batch);
+        Assert.Contains(inUse.Styles, style => style.Name == "Callout");
+
+        // The style cannot be deleted while a paragraph still uses it in a way that matters, so the
+        // paragraph is reset first.
+        Paragraphs.SetStyle(Batch, 1, "Normal");
+
+        var deleted = Styles.Delete(Batch, "Callout");
+        Assert.Contains("deleted", deleted.Message, StringComparison.OrdinalIgnoreCase);
+
+        Assert.DoesNotContain(Styles.List(Batch, inUseOnly: false).Styles, style => style.Name == "Callout");
+    }
+
+    [Fact]
+    public void Style_CreateRejectsExistingName()
+    {
+        Styles.Create(Batch, "Duplicate");
+
+        Assert.Throws<ArgumentException>(() => Styles.Create(Batch, "Duplicate"));
+    }
+
+    [Fact]
+    public void Style_ModifyRejectsUnknownStyle()
+        => Assert.Throws<ArgumentException>(() => Styles.Modify(Batch, "No Such Style", bold: true));
+
+    [Fact]
+    public void Style_ModifyAcceptsEnglishNameOfBuiltInStyle()
+    {
+        var modified = Styles.Modify(Batch, "Heading 1", fontSize: 20);
+
+        Assert.Equal(20, modified.Style!.FontSize);
+        Assert.True(modified.Style.BuiltIn);
+        Assert.Equal("Heading 1", modified.Style.EnglishName);
+    }
+
+    [Fact]
+    public void Style_DeleteRefusesBuiltInStyle()
+        => Assert.Throws<InvalidOperationException>(() => Styles.Delete(Batch, "Heading 1"));
+
+    [Fact]
+    public void Style_DeleteRejectsUnknownStyle()
+        => Assert.Throws<ArgumentException>(() => Styles.Delete(Batch, "No Such Style"));
+
+    public void Dispose()
+    {
+        _sessions.Dispose();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A locked temp file must not fail the test run.
+        }
+    }
+}

--- a/tests/WordMcp.Core.Tests/StyleValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/StyleValidationTests.cs
@@ -1,0 +1,80 @@
+using WordMcp.Core.Commands.Style;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Argument validation of the style commands. Everything asserted here happens before the batch is
+/// touched, so these tests need no Word installation and run in CI.
+/// </summary>
+public class StyleValidationTests
+{
+    private static readonly StyleCommands Styles = new();
+    private static readonly ThrowingBatch Batch = new();
+
+    [Fact]
+    public void List_RejectsUnknownStyleType()
+        => Assert.Throws<ArgumentException>(() => Styles.List(Batch, styleType: "sideways"));
+
+    [Theory]
+    [InlineData("paragraph")]
+    [InlineData("character")]
+    [InlineData("table")]
+    [InlineData("list")]
+    public void List_AcceptsKnownStyleTypes(string styleType)
+        => Assert.Throws<NotSupportedException>(() => Styles.List(Batch, styleType: styleType));
+
+    [Fact]
+    public void Create_RejectsEmptyName()
+        => Assert.Throws<ArgumentException>(() => Styles.Create(Batch, "  "));
+
+    [Fact]
+    public void Create_RejectsUnknownStyleType()
+        => Assert.Throws<ArgumentException>(() => Styles.Create(Batch, "Callout", "sideways"));
+
+    [Fact]
+    public void Create_DefaultsToParagraphStyle()
+        => Assert.Throws<NotSupportedException>(() => Styles.Create(Batch, "Callout"));
+
+    [Fact]
+    public void Modify_RejectsEmptyName()
+        => Assert.Throws<ArgumentException>(() => Styles.Modify(Batch, "", bold: true));
+
+    [Fact]
+    public void Modify_RejectsNonPositiveFontSize()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Styles.Modify(Batch, "Callout", fontSize: 0));
+
+    [Fact]
+    public void Modify_RejectsNonPositiveLineSpacing()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Styles.Modify(Batch, "Callout", lineSpacing: -1));
+
+    [Fact]
+    public void Modify_RejectsUnknownColor()
+        => Assert.Throws<ArgumentException>(() => Styles.Modify(Batch, "Callout", color: "not-a-color"));
+
+    [Fact]
+    public void Modify_RejectsUnknownAlignment()
+        => Assert.Throws<ArgumentException>(() => Styles.Modify(Batch, "Callout", alignment: "sideways"));
+
+    [Fact]
+    public void Modify_AcceptsValidFormatting()
+        => Assert.Throws<NotSupportedException>(
+            () => Styles.Modify(Batch, "Callout", color: "#C00000", alignment: "center", fontSize: 11));
+
+    [Fact]
+    public void Delete_RejectsEmptyName()
+        => Assert.Throws<ArgumentException>(() => Styles.Delete(Batch, "   "));
+
+    [Fact]
+    public void Delete_ReachesBatchForValidName()
+        => Assert.Throws<NotSupportedException>(() => Styles.Delete(Batch, "Callout"));
+
+    [Fact]
+    public void AllCommands_RejectNullBatch()
+    {
+        Assert.Throws<ArgumentNullException>(() => Styles.List(null!));
+        Assert.Throws<ArgumentNullException>(() => Styles.Create(null!, "Callout"));
+        Assert.Throws<ArgumentNullException>(() => Styles.Modify(null!, "Callout"));
+        Assert.Throws<ArgumentNullException>(() => Styles.Delete(null!, "Callout"));
+    }
+}

--- a/tests/WordMcp.Core.Tests/WordConversionsStyleTests.cs
+++ b/tests/WordMcp.Core.Tests/WordConversionsStyleTests.cs
@@ -1,0 +1,64 @@
+using WordMcp.ComInterop;
+using WordMcp.Core.Utilities;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Conversions between the friendly style-type names on the wire and Word's WdStyleType constants.
+/// </summary>
+public class WordConversionsStyleTests
+{
+    [Theory]
+    [InlineData("paragraph", ComInteropConstants.WdStyleTypeParagraph)]
+    [InlineData("character", ComInteropConstants.WdStyleTypeCharacter)]
+    [InlineData("table", ComInteropConstants.WdStyleTypeTable)]
+    [InlineData("list", ComInteropConstants.WdStyleTypeList)]
+    public void ToWdStyleType_MapsKnownNames(string styleType, int expected)
+        => Assert.Equal(expected, WordConversions.ToWdStyleType(styleType));
+
+    [Theory]
+    [InlineData("PARAGRAPH")]
+    [InlineData("  Character  ")]
+    public void ToWdStyleType_IgnoresCaseAndSurroundingSpace(string styleType)
+        => Assert.True(WordConversions.ToWdStyleType(styleType) > 0);
+
+    [Fact]
+    public void ToWdStyleType_RejectsUnknownName()
+        => Assert.Throws<ArgumentException>(() => WordConversions.ToWdStyleType("sideways"));
+
+    [Fact]
+    public void ToWdStyleType_RejectsEmptyName()
+        => Assert.Throws<ArgumentException>(() => WordConversions.ToWdStyleType("  "));
+
+    [Theory]
+    [InlineData(ComInteropConstants.WdStyleTypeParagraph, "paragraph")]
+    [InlineData(ComInteropConstants.WdStyleTypeCharacter, "character")]
+    [InlineData(ComInteropConstants.WdStyleTypeTable, "table")]
+    [InlineData(ComInteropConstants.WdStyleTypeList, "list")]
+    public void FromWdStyleType_MapsKnownConstants(int wdStyleType, string expected)
+        => Assert.Equal(expected, WordConversions.FromWdStyleType(wdStyleType));
+
+    [Fact]
+    public void FromWdStyleType_FallsBackForUnknownConstants()
+        => Assert.Equal("other", WordConversions.FromWdStyleType(99));
+
+    [Theory]
+    [InlineData("paragraph")]
+    [InlineData("character")]
+    [InlineData("table")]
+    [InlineData("list")]
+    public void StyleTypeConversion_RoundTrips(string styleType)
+        => Assert.Equal(styleType, WordConversions.FromWdStyleType(WordConversions.ToWdStyleType(styleType)));
+
+    [Fact]
+    public void KnownBuiltInStyles_CoversTheStylesWordStylesResolves()
+    {
+        Assert.NotEmpty(WordStyles.KnownBuiltInStyles);
+
+        foreach (var entry in WordStyles.KnownBuiltInStyles)
+        {
+            Assert.Equal(entry.Value, WordStyles.Resolve(entry.Key));
+        }
+    }
+}


### PR DESCRIPTION
Adds the `style` tool: list, create, modify and delete document styles.

## Why

Styles are how a Word document keeps formatting consistent. Without them a client has to set font, size and spacing on every paragraph individually, and the result drifts apart. This is the first tool built entirely on the generated tool layer from #26 — it consists of an interface, a COM implementation and a `WordServices` property. No tool code was written by hand.

## The localization problem

Word reports styles under localized names. On the German Word this repo is tested against, `Heading 1` is `Ueberschrift 1`, so a client that only knows English names cannot address anything it reads back.

`style(list)` therefore returns both: `name` as Word reports it and `english_name` for the built-in styles the server can map. Lookups accept either, so `style(modify, name: "Heading 1")` works on any language version.

## Behaviour worth knowing

- `list` defaults to `in_use_only: true`. The full list is over 370 entries on a localized Word and is rarely what a caller wants.
- `delete` rejects built-in styles with a clear message rather than passing Word's generic COM error through.
- `modify` only writes the properties that were passed; everything else stays as it is.
- `line_spacing` sets the spacing rule to "exactly" first, because Word ignores the value otherwise.

## Tests

- 15 validation tests and 9 conversion tests that need no Word installation, so they run in CI.
- 9 integration tests against real Word covering the create → modify → apply → delete round trip, the English-name lookup on a German install, and both delete guards.
- The existing `GeneratedToolContractTests` picked the new tool up automatically (61 → 65 tests).

Full run: 245 Core tests and 65 McpServer tests green. Release build has 0 warnings.

Closes #21