### PR TITLE
Add list tool for bullets, numbering and levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ file(open|create) ──► session_id ──► text / paragraph / table / docu
 
 ## Tools
 
-Ten tools, each with an `action` parameter.
+Eleven tools, each with an `action` parameter.
 
 ### `file` — session lifecycle
 
@@ -209,6 +209,26 @@ style(action: "modify", session_id: "...", name: "Callout",
 
 ---
 
+### `list` — bullets and numbering
+
+| Action | Purpose |
+|---|---|
+| `get` | Report the list formatting of the paragraphs, including the rendered bullet or number |
+| `apply` | Format a paragraph range as a `bullet`, `number` or `outline-number` list |
+| `set-level` | Set the list level of a paragraph range (1–9) |
+| `restart` | Start the numbering over at a paragraph |
+| `remove` | Strip the list formatting |
+
+Omitting `end_index` applies the action to `start_index` alone.
+
+```jsonc
+list(action: "apply", session_id: "...", start_index: 2, end_index: 5, list_type: "number")
+list(action: "set-level", session_id: "...", start_index: 3, end_index: 4, level: 2)
+list(action: "restart", session_id: "...", start_index: 6)
+```
+
+---
+
 ## Responses
 
 Every tool returns JSON. Failures are reported as structured payloads, never as a transport error:
@@ -246,6 +266,8 @@ Every tool returns JSON. Failures are reported as structured payloads, never as 
 * **`section(page-setup)` applies `paper_size` before the margins**, because changing the paper size resets them in Word. Without a `section_index` the setup is applied to every section.
 * **Headers and footers are inherited between sections.** A new section shows the previous section's header until something is written to it. `header-footer(set)` with a `section_index` breaks that link automatically, so section 1 keeps its own text.
 * **`first-page` and `even-pages` headers need a section switch.** `header-footer(set)` turns on `DifferentFirstPage` respectively `DifferentOddEvenPages` for you — without it Word stores the text but never renders it.
+* **`list(apply)` starts a new list by default.** `continue_previous_list` is off, because picking up the numbering of an unrelated earlier list is rarely what was meant. Two numbered lists separated by plain paragraphs stay independent; use `list(restart)` when Word merges them anyway.
+* **Only outline-number lists render distinct levels.** `list(set-level)` works on any list, but a plain `bullet` or `number` list shows the same marker on every level — the paragraphs are merely indented.
 
 ---
 
@@ -266,13 +288,13 @@ dotnet test WordMcp.sln --filter "Category!=RequiresWord"
 | `src/WordMcp.Core` | Command interfaces, command implementations and result models |
 | `src/WordMcp.Generators.Shared` | Source files shared by the generators; not a project of its own |
 | `src/WordMcp.Generators.Mcp` | Roslyn source generator that emits the MCP tool classes |
-| `src/WordMcp.McpServer` | stdio MCP server exposing the ten tools |
+| `src/WordMcp.McpServer` | stdio MCP server exposing the eleven tools |
 | `tests/WordMcp.Core.Tests` | Unit tests plus integration tests against a real Word |
 | `tests/WordMcp.McpServer.Tests` | Tool-layer unit tests, no Word required |
 
 ### Generated tool layer
 
-Nine of the ten tools are generated at build time. The command interfaces in
+Ten of the eleven tools are generated at build time. The command interfaces in
 `src/WordMcp.Core/Commands` are the single source of truth for the wire contract:
 
 - `[ServiceCategory("section", "Section")]` names the tool class, `WordSectionTool`.

--- a/src/WordMcp.ComInterop/ComInteropConstants.cs
+++ b/src/WordMcp.ComInterop/ComInteropConstants.cs
@@ -219,6 +219,58 @@ public static class ComInteropConstants
 
     #endregion
 
+    #region Lists
+
+    /// <summary>WdListGalleryType.wdBulletGallery = 1.</summary>
+    public const int WdBulletGallery = 1;
+
+    /// <summary>WdListGalleryType.wdNumberGallery = 2.</summary>
+    public const int WdNumberGallery = 2;
+
+    /// <summary>WdListGalleryType.wdOutlineNumberGallery = 3.</summary>
+    public const int WdOutlineNumberGallery = 3;
+
+    /// <summary>WdListApplyTo.wdListApplyToWholeList = 0.</summary>
+    public const int WdListApplyToWholeList = 0;
+
+    /// <summary>WdListApplyTo.wdListApplyToSelection = 2.</summary>
+    public const int WdListApplyToSelection = 2;
+
+    /// <summary>
+    /// WdDefaultListBehavior.wdWord10ListBehavior = 2. The modern behaviour, which is the only one
+    /// that keeps multi-level lists intact.
+    /// </summary>
+    public const int WdWord10ListBehavior = 2;
+
+    /// <summary>WdNumberType.wdNumberParagraph = 1.</summary>
+    public const int WdNumberParagraph = 1;
+
+    /// <summary>WdNumberType.wdNumberAllNumbers = 3.</summary>
+    public const int WdNumberAllNumbers = 3;
+
+    /// <summary>WdListType.wdListNoNumbering = 0.</summary>
+    public const int WdListNoNumbering = 0;
+
+    /// <summary>WdListType.wdListListNumOnly = 1.</summary>
+    public const int WdListListNumOnly = 1;
+
+    /// <summary>WdListType.wdListBullet = 2.</summary>
+    public const int WdListBullet = 2;
+
+    /// <summary>WdListType.wdListSimpleNumbering = 3.</summary>
+    public const int WdListSimpleNumbering = 3;
+
+    /// <summary>WdListType.wdListOutlineNumbering = 4.</summary>
+    public const int WdListOutlineNumbering = 4;
+
+    /// <summary>WdListType.wdListMixedNumbering = 5.</summary>
+    public const int WdListMixedNumbering = 5;
+
+    /// <summary>Highest list level Word supports.</summary>
+    public const int MaxListLevel = 9;
+
+    #endregion
+
     #region Supported extensions
 
     /// <summary>

--- a/src/WordMcp.Core/Commands/List/IListCommands.cs
+++ b/src/WordMcp.Core/Commands/List/IListCommands.cs
@@ -1,0 +1,103 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.List;
+
+/// <summary>
+/// List operations: bullets, numbering, levels and restarting numbering.
+/// </summary>
+[ServiceCategory("list", "List")]
+[McpTool("list",
+    Title = "List Operations",
+    Description = "Bullet and numbered list operations on an open document. "
+        + "list(apply, session_id, start_index=2, end_index=5, list_type='number') turns a range of "
+        + "paragraphs into a numbered list; list_type can be bullet, number or outline-number. "
+        + "list(set-level, session_id, start_index=3, end_index=4, level=2) indents paragraphs to a "
+        + "sub-level; levels run from 1 to 9 and only outline-number lists render a distinct format "
+        + "per level. "
+        + "list(restart, session_id, start_index=6) starts the numbering over at that paragraph, "
+        + "which is how two separate numbered lists are kept apart. "
+        + "list(remove, session_id, start_index=2, end_index=5) strips the list formatting again. "
+        + "list(get, session_id) reports the list formatting of every paragraph, including the "
+        + "bullet or number Word renders. "
+        + "Paragraph indexes are 1-based and shift whenever paragraphs are added or removed, so "
+        + "read them with paragraph(list) right before using them. "
+        + "Omitting end_index applies the action to start_index alone.")]
+public interface IListCommands
+{
+    /// <summary>
+    /// Reports the list formatting of the paragraphs of the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="listedOnly">
+    /// Whether to return only paragraphs that carry list formatting. Defaults to true.
+    /// </param>
+    /// <returns>The matching paragraphs.</returns>
+    [ServiceAction("get")]
+    ListResult Get(IWordBatch batch, bool listedOnly = true);
+
+    /// <summary>
+    /// Formats a range of paragraphs as a bullet or numbered list.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="startIndex">1-based index of the first paragraph.</param>
+    /// <param name="endIndex">
+    /// 1-based index of the last paragraph. Defaults to the start paragraph.
+    /// </param>
+    /// <param name="listType">
+    /// The kind of list: bullet, number or outline-number. Defaults to bullet.
+    /// </param>
+    /// <param name="level">The list level to apply, from 1 to 9. Defaults to 1.</param>
+    /// <param name="continuePreviousList">
+    /// Whether a numbered list continues the numbering of the preceding list instead of starting at
+    /// 1. Defaults to false, because continuing an unrelated earlier list is rarely intended.
+    /// </param>
+    /// <returns>The formatted paragraphs.</returns>
+    [ServiceAction("apply")]
+    ListResult Apply(
+        IWordBatch batch,
+        int startIndex,
+        int? endIndex = null,
+        string listType = "bullet",
+        int level = 1,
+        bool continuePreviousList = false);
+
+    /// <summary>
+    /// Sets the list level of a range of paragraphs.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="startIndex">1-based index of the first paragraph.</param>
+    /// <param name="level">The list level, from 1 to 9.</param>
+    /// <param name="endIndex">
+    /// 1-based index of the last paragraph. Defaults to the start paragraph.
+    /// </param>
+    /// <returns>The changed paragraphs.</returns>
+    [ServiceAction("set-level")]
+    ListResult SetLevel(IWordBatch batch, int startIndex, int level, int? endIndex = null);
+
+    /// <summary>
+    /// Restarts the numbering of a list at a paragraph.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="startIndex">1-based index of the paragraph the numbering restarts at.</param>
+    /// <param name="endIndex">
+    /// 1-based index of the last paragraph of the restarted list. Defaults to the end of the list
+    /// the start paragraph belongs to.
+    /// </param>
+    /// <returns>The changed paragraphs.</returns>
+    [ServiceAction("restart")]
+    ListResult Restart(IWordBatch batch, int startIndex, int? endIndex = null);
+
+    /// <summary>
+    /// Removes the list formatting of a range of paragraphs.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="startIndex">1-based index of the first paragraph.</param>
+    /// <param name="endIndex">
+    /// 1-based index of the last paragraph. Defaults to the start paragraph.
+    /// </param>
+    /// <returns>The changed paragraphs.</returns>
+    [ServiceAction("remove")]
+    ListResult Remove(IWordBatch batch, int startIndex, int? endIndex = null);
+}

--- a/src/WordMcp.Core/Commands/List/ListCommands.cs
+++ b/src/WordMcp.Core/Commands/List/ListCommands.cs
@@ -1,0 +1,302 @@
+using System.Runtime.InteropServices;
+using WordMcp.ComInterop;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+using Word = Microsoft.Office.Interop.Word;
+
+namespace WordMcp.Core.Commands.List;
+
+/// <summary>
+/// Word COM implementation of <see cref="IListCommands"/>.
+/// </summary>
+public sealed class ListCommands : IListCommands
+{
+    /// <inheritdoc />
+    public ListResult Get(IWordBatch batch, bool listedOnly = true)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic paragraphs = doc.Paragraphs;
+            int total = (int)paragraphs.Count;
+
+            var list = new List<ListParagraphInfo>();
+
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var info = Describe(paragraphs[i], i);
+                if (listedOnly && info.ListType == "none")
+                    continue;
+
+                list.Add(info);
+            }
+
+            return new ListResult
+            {
+                Paragraphs = list,
+                UpdatedCount = 0,
+                TotalCount = total
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ListResult Apply(
+        IWordBatch batch,
+        int startIndex,
+        int? endIndex = null,
+        string listType = "bullet",
+        int level = 1,
+        bool continuePreviousList = false)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 1);
+        ValidateLevel(level);
+
+        int gallery = WordConversions.ToWdListGallery(listType);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            (int first, int last) = ResolveRange((int)doc.Paragraphs.Count, startIndex, endIndex);
+
+            // ListGalleries lives on the Application, not on the Document. The property is
+            // strongly typed, so the gallery constant has to be cast back to its enum.
+            dynamic template = ctx.App.ListGalleries[(Word.WdListGalleryType)gallery].ListTemplates[1];
+            dynamic range = RangeOf(doc, first, last);
+
+            range.ListFormat.ApplyListTemplateWithLevel(
+                template,
+                continuePreviousList,
+                ComInteropConstants.WdListApplyToSelection,
+                ComInteropConstants.WdWord10ListBehavior,
+                1);
+
+            // The gallery template always lands on level 1, so a deeper level is a second step.
+            if (level > 1)
+            {
+                SetLevels(doc, first, last, level);
+            }
+
+            return Result(doc, first, last, $"List formatting applied to paragraphs {first}-{last}.");
+        });
+    }
+
+    /// <inheritdoc />
+    public ListResult SetLevel(IWordBatch batch, int startIndex, int level, int? endIndex = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 1);
+        ValidateLevel(level);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            (int first, int last) = ResolveRange((int)doc.Paragraphs.Count, startIndex, endIndex);
+
+            SetLevels(doc, first, last, level);
+
+            return Result(doc, first, last, $"Paragraphs {first}-{last} set to list level {level}.");
+        });
+    }
+
+    /// <inheritdoc />
+    public ListResult Restart(IWordBatch batch, int startIndex, int? endIndex = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 1);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            (int first, int _) = ResolveRange((int)doc.Paragraphs.Count, startIndex, endIndex);
+
+            dynamic startParagraph = doc.Paragraphs[first];
+            dynamic startFormat = startParagraph.Range.ListFormat;
+
+            if ((int)startFormat.ListType == ComInteropConstants.WdListNoNumbering)
+            {
+                throw new ArgumentException(
+                    $"Paragraph {first} is not part of a list, so there is no numbering to restart.",
+                    nameof(startIndex));
+            }
+
+            // Without an explicit end, the restart has to cover the rest of the list; stopping
+            // earlier would split it into a third list at that point.
+            int last = endIndex ?? FindListEnd(doc, first);
+
+            dynamic template = startFormat.ListTemplate;
+            dynamic range = RangeOf(doc, first, last);
+
+            // Re-applying the same template with ContinuePreviousList off is what makes Word treat
+            // this as a new list and start counting at 1 again. ApplyTo has to be the range rather
+            // than the whole list, or Word keeps the paragraphs in the original list and the
+            // numbering just carries on.
+            range.ListFormat.ApplyListTemplateWithLevel(
+                template,
+                false,
+                ComInteropConstants.WdListApplyToSelection,
+                ComInteropConstants.WdWord10ListBehavior,
+                1);
+
+            return Result(doc, first, last, $"Numbering restarted at paragraph {first}.");
+        });
+    }
+
+    /// <inheritdoc />
+    public ListResult Remove(IWordBatch batch, int startIndex, int? endIndex = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(startIndex, 1);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            (int first, int last) = ResolveRange((int)doc.Paragraphs.Count, startIndex, endIndex);
+
+            RangeOf(doc, first, last).ListFormat.RemoveNumbers(ComInteropConstants.WdNumberAllNumbers);
+
+            return Result(doc, first, last, $"List formatting removed from paragraphs {first}-{last}.");
+        });
+    }
+
+    private static void ValidateLevel(int level)
+    {
+        if (level is < 1 or > ComInteropConstants.MaxListLevel)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(level), level, $"level must be between 1 and {ComInteropConstants.MaxListLevel}.");
+        }
+    }
+
+    private static (int First, int Last) ResolveRange(int total, int startIndex, int? endIndex)
+    {
+        if (startIndex > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(startIndex),
+                $"Paragraph {startIndex} does not exist. The document has {total} paragraph(s).");
+        }
+
+        int last = endIndex ?? startIndex;
+
+        if (last < startIndex)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(endIndex), $"end_index {last} is before start_index {startIndex}.");
+        }
+
+        if (last > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(endIndex),
+                $"Paragraph {last} does not exist. The document has {total} paragraph(s).");
+        }
+
+        return (startIndex, last);
+    }
+
+    private static dynamic RangeOf(dynamic doc, int first, int last)
+        => doc.Range(doc.Paragraphs[first].Range.Start, doc.Paragraphs[last].Range.End);
+
+    private static void SetLevels(dynamic doc, int first, int last, int level)
+    {
+        for (int i = first; i <= last; i++)
+        {
+            dynamic format = doc.Paragraphs[i].Range.ListFormat;
+
+            if ((int)format.ListType == ComInteropConstants.WdListNoNumbering)
+            {
+                throw new ArgumentException(
+                    $"Paragraph {i} is not part of a list. Apply list formatting before setting a level.",
+                    nameof(level));
+            }
+
+            try
+            {
+                format.ListLevelNumber = level;
+            }
+            catch (COMException ex)
+            {
+                throw new ArgumentException(
+                    $"Word rejected list level {level} for paragraph {i}. Only outline-number lists "
+                        + "support more than one level.",
+                    nameof(level),
+                    ex);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walks forward from a paragraph to the last paragraph that still belongs to the same list.
+    /// </summary>
+    private static int FindListEnd(dynamic doc, int first)
+    {
+        int total = (int)doc.Paragraphs.Count;
+        int last = first;
+
+        for (int i = first + 1; i <= total; i++)
+        {
+            if ((int)doc.Paragraphs[i].Range.ListFormat.ListType == ComInteropConstants.WdListNoNumbering)
+                break;
+
+            last = i;
+        }
+
+        return last;
+    }
+
+    private static ListResult Result(dynamic doc, int first, int last, string message)
+    {
+        var touched = new List<ListParagraphInfo>();
+
+        for (int i = first; i <= last; i++)
+        {
+            touched.Add(Describe(doc.Paragraphs[i], i));
+        }
+
+        return new ListResult
+        {
+            Paragraphs = touched,
+            UpdatedCount = touched.Count,
+            TotalCount = (int)doc.Paragraphs.Count,
+            Message = message
+        };
+    }
+
+    private static ListParagraphInfo Describe(dynamic paragraph, int index)
+    {
+        dynamic range = paragraph.Range;
+        dynamic format = range.ListFormat;
+
+        int listType = (int)format.ListType;
+        bool inList = listType != ComInteropConstants.WdListNoNumbering;
+
+        return new ListParagraphInfo
+        {
+            Index = index,
+            Text = WordConversions.CleanRangeText((string?)range.Text),
+            ListType = WordConversions.FromWdListType(listType),
+            Level = inList ? ReadLevel(format) : 0,
+            ListLabel = inList ? ((string?)format.ListString ?? string.Empty).Trim() : string.Empty
+        };
+    }
+
+    private static int ReadLevel(dynamic format)
+    {
+        try
+        {
+            return (int)format.ListLevelNumber;
+        }
+        catch (COMException)
+        {
+            // Word refuses to report a level for some list shapes; the list type still is useful.
+            return 0;
+        }
+    }
+}

--- a/src/WordMcp.Core/Models/ListResults.cs
+++ b/src/WordMcp.Core/Models/ListResults.cs
@@ -1,0 +1,43 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// List formatting of a single paragraph.
+/// </summary>
+public sealed class ListParagraphInfo
+{
+    /// <summary>Gets or sets the 1-based paragraph index.</summary>
+    public int Index { get; set; }
+
+    /// <summary>Gets or sets the paragraph text.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the kind of list: <c>bullet</c>, <c>number</c>, <c>outline-number</c> or
+    /// <c>none</c> when the paragraph carries no list formatting.
+    /// </summary>
+    public string ListType { get; set; } = "none";
+
+    /// <summary>Gets or sets the 1-based list level, or 0 when the paragraph is not in a list.</summary>
+    public int Level { get; set; }
+
+    /// <summary>
+    /// Gets or sets the bullet or number Word renders in front of the paragraph, such as
+    /// <c>2.</c> or <c>a)</c>. Empty when the paragraph is not in a list.
+    /// </summary>
+    public string ListLabel { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Result of an operation that changes list formatting.
+/// </summary>
+public sealed class ListResult : ResultBase
+{
+    /// <summary>Gets or sets the paragraphs the operation touched.</summary>
+    public IReadOnlyList<ListParagraphInfo> Paragraphs { get; set; } = [];
+
+    /// <summary>Gets or sets the number of paragraphs the operation touched.</summary>
+    public int UpdatedCount { get; set; }
+
+    /// <summary>Gets or sets the number of paragraphs in the document.</summary>
+    public int TotalCount { get; set; }
+}

--- a/src/WordMcp.Core/Utilities/WordConversions.cs
+++ b/src/WordMcp.Core/Utilities/WordConversions.cs
@@ -293,6 +293,41 @@ public static class WordConversions
         _ => "other"
     };
 
+    /// <summary>
+    /// Converts a friendly list kind into the <c>WdListGalleryType</c> constant.
+    /// </summary>
+    /// <param name="listType">The list kind: bullet, number or outline-number.</param>
+    /// <returns>The Word list gallery constant.</returns>
+    /// <exception cref="ArgumentException">The kind is unknown.</exception>
+    public static int ToWdListGallery(string listType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(listType);
+
+        return NormalizeName(listType) switch
+        {
+            "bullet" or "bullets" => ComInteropConstants.WdBulletGallery,
+            "number" or "numbered" or "numbering" => ComInteropConstants.WdNumberGallery,
+            "outline-number" or "outline" => ComInteropConstants.WdOutlineNumberGallery,
+            _ => throw new ArgumentException(
+                $"Unknown list type '{listType}'. Use one of: bullet, number, outline-number.",
+                nameof(listType))
+        };
+    }
+
+    /// <summary>
+    /// Converts a <c>WdListType</c> value to its friendly name.
+    /// </summary>
+    /// <param name="wdListType">The Word list type constant.</param>
+    /// <returns>The friendly list kind name.</returns>
+    public static string FromWdListType(int wdListType) => wdListType switch
+    {
+        ComInteropConstants.WdListNoNumbering => "none",
+        ComInteropConstants.WdListBullet => "bullet",
+        ComInteropConstants.WdListListNumOnly or ComInteropConstants.WdListSimpleNumbering => "number",
+        ComInteropConstants.WdListOutlineNumbering or ComInteropConstants.WdListMixedNumbering => "outline-number",
+        _ => "other"
+    };
+
     private static string NormalizeName(string value)
         => value.Trim().ToLowerInvariant().Replace('_', '-').Replace(" ", string.Empty, StringComparison.Ordinal);
 }

--- a/src/WordMcp.McpServer/WordServices.cs
+++ b/src/WordMcp.McpServer/WordServices.cs
@@ -4,6 +4,7 @@ using WordMcp.Core.Commands.Document;
 using WordMcp.Core.Commands.Field;
 using WordMcp.Core.Commands.HeaderFooter;
 using WordMcp.Core.Commands.Image;
+using WordMcp.Core.Commands.List;
 using WordMcp.Core.Commands.Paragraph;
 using WordMcp.Core.Commands.Section;
 using WordMcp.Core.Commands.Style;
@@ -65,6 +66,9 @@ internal static class WordServices
 
     /// <summary>Gets the style command implementation.</summary>
     public static IStyleCommands Styles { get; } = new StyleCommands();
+
+    /// <summary>Gets the list command implementation.</summary>
+    public static IListCommands Lists { get; } = new ListCommands();
 
     /// <summary>
     /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.

--- a/tests/WordMcp.Core.Tests/ListIntegrationTests.cs
+++ b/tests/WordMcp.Core.Tests/ListIntegrationTests.cs
@@ -1,0 +1,201 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.List;
+using WordMcp.Core.Commands.Paragraph;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Integration tests for the list commands. They use their own document because list numbering is
+/// document-wide state that would leak between assertions of the shared fixture.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class ListIntegrationTests : IDisposable
+{
+    private static readonly ListCommands Lists = new();
+    private static readonly ParagraphCommands Paragraphs = new();
+
+    private readonly SessionManager _sessions = new();
+    private readonly string _directory;
+    private readonly string _sessionId;
+
+    private IWordBatch Batch => _sessions.GetBatch(_sessionId);
+
+    public ListIntegrationTests()
+    {
+        _directory = Directory
+            .CreateDirectory(Path.Combine(Path.GetTempPath(), "wordmcp-list-" + Guid.NewGuid().ToString("N")))
+            .FullName;
+
+        _sessionId = _sessions.Create(Path.Combine(_directory, "lists.docx")).SessionId;
+    }
+
+    /// <summary>
+    /// Adds paragraphs and returns the 1-based index of the first one.
+    /// </summary>
+    private int AddParagraphs(params string[] texts)
+    {
+        int first = 0;
+
+        foreach (string text in texts)
+        {
+            var result = Paragraphs.Add(Batch, text);
+            first = first == 0 ? result.Paragraph!.Index : first;
+        }
+
+        return first;
+    }
+
+    [Fact]
+    public void List_GetReportsNothingForDocumentWithoutLists()
+    {
+        AddParagraphs("Plain text");
+
+        var lists = Lists.Get(Batch);
+
+        Assert.Empty(lists.Paragraphs);
+        Assert.True(lists.TotalCount > 0);
+    }
+
+    [Fact]
+    public void List_GetIncludesUnlistedParagraphsOnRequest()
+    {
+        AddParagraphs("Plain text");
+
+        var all = Lists.Get(Batch, listedOnly: false);
+
+        Assert.NotEmpty(all.Paragraphs);
+        Assert.Contains(all.Paragraphs, p => p.ListType == "none" && p.Level == 0);
+    }
+
+    [Fact]
+    public void List_ApplyBulletsFormatsTheRange()
+    {
+        int first = AddParagraphs("Apples", "Pears", "Plums");
+
+        var applied = Lists.Apply(Batch, first, first + 2);
+
+        Assert.Equal(3, applied.UpdatedCount);
+        Assert.All(applied.Paragraphs, p => Assert.Equal("bullet", p.ListType));
+        Assert.All(applied.Paragraphs, p => Assert.Equal(1, p.Level));
+        Assert.All(applied.Paragraphs, p => Assert.NotEmpty(p.ListLabel));
+    }
+
+    [Fact]
+    public void List_ApplyNumbersProducesAscendingLabels()
+    {
+        int first = AddParagraphs("First", "Second", "Third");
+
+        var applied = Lists.Apply(Batch, first, first + 2, "number");
+
+        Assert.All(applied.Paragraphs, p => Assert.Equal("number", p.ListType));
+        Assert.StartsWith("1", applied.Paragraphs[0].ListLabel, StringComparison.Ordinal);
+        Assert.StartsWith("2", applied.Paragraphs[1].ListLabel, StringComparison.Ordinal);
+        Assert.StartsWith("3", applied.Paragraphs[2].ListLabel, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void List_ApplyWithoutEndIndexTouchesOneParagraph()
+    {
+        int first = AddParagraphs("Only this one", "Not this one");
+
+        var applied = Lists.Apply(Batch, first);
+
+        Assert.Equal(1, applied.UpdatedCount);
+        Assert.Equal("bullet", applied.Paragraphs[0].ListType);
+    }
+
+    [Fact]
+    public void List_SetLevelIndentsParagraphsOfAnOutlineList()
+    {
+        int first = AddParagraphs("Chapter", "Detail", "Detail two", "Chapter two");
+        Lists.Apply(Batch, first, first + 3, "outline-number");
+
+        var nested = Lists.SetLevel(Batch, first + 1, 2, first + 2);
+
+        Assert.Equal(2, nested.UpdatedCount);
+        Assert.All(nested.Paragraphs, p => Assert.Equal(2, p.Level));
+
+        var all = Lists.Get(Batch);
+        Assert.Equal(1, all.Paragraphs.Single(p => p.Index == first).Level);
+        Assert.Equal(1, all.Paragraphs.Single(p => p.Index == first + 3).Level);
+    }
+
+    [Fact]
+    public void List_SetLevelRejectsParagraphOutsideAList()
+    {
+        int first = AddParagraphs("Not a list item");
+
+        Assert.Throws<ArgumentException>(() => Lists.SetLevel(Batch, first, 2));
+    }
+
+    [Fact]
+    public void List_RestartBeginsNumberingAtOneAgain()
+    {
+        int first = AddParagraphs("One", "Two", "Three", "Four");
+        Lists.Apply(Batch, first, first + 3, "number");
+
+        var restarted = Lists.Restart(Batch, first + 2);
+
+        Assert.StartsWith("1", restarted.Paragraphs[0].ListLabel, StringComparison.Ordinal);
+
+        var all = Lists.Get(Batch);
+        Assert.StartsWith("1", all.Paragraphs.Single(p => p.Index == first).ListLabel, StringComparison.Ordinal);
+        Assert.StartsWith("2", all.Paragraphs.Single(p => p.Index == first + 1).ListLabel, StringComparison.Ordinal);
+        Assert.StartsWith("1", all.Paragraphs.Single(p => p.Index == first + 2).ListLabel, StringComparison.Ordinal);
+        Assert.StartsWith("2", all.Paragraphs.Single(p => p.Index == first + 3).ListLabel, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void List_RestartRejectsParagraphOutsideAList()
+    {
+        int first = AddParagraphs("Not a list item");
+
+        Assert.Throws<ArgumentException>(() => Lists.Restart(Batch, first));
+    }
+
+    [Fact]
+    public void List_RemoveStripsTheFormatting()
+    {
+        int first = AddParagraphs("Alpha", "Beta");
+        Lists.Apply(Batch, first, first + 1, "number");
+
+        var removed = Lists.Remove(Batch, first, first + 1);
+
+        Assert.Equal(2, removed.UpdatedCount);
+        Assert.All(removed.Paragraphs, p => Assert.Equal("none", p.ListType));
+        Assert.All(removed.Paragraphs, p => Assert.Empty(p.ListLabel));
+
+        Assert.DoesNotContain(Lists.Get(Batch).Paragraphs, p => p.Index == first);
+    }
+
+    [Fact]
+    public void List_RejectsRangeBeyondTheDocument()
+    {
+        int first = AddParagraphs("Only paragraph");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Lists.Apply(Batch, first, first + 50));
+    }
+
+    [Fact]
+    public void List_RejectsEndIndexBeforeStartIndex()
+    {
+        int first = AddParagraphs("A", "B");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Lists.Apply(Batch, first + 1, first));
+    }
+
+    public void Dispose()
+    {
+        _sessions.Dispose();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A locked temp file must not fail the test run.
+        }
+    }
+}

--- a/tests/WordMcp.Core.Tests/ListValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/ListValidationTests.cs
@@ -1,0 +1,71 @@
+using WordMcp.Core.Commands.List;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Argument validation of the list commands. Everything asserted here happens before the batch is
+/// touched, so these tests need no Word installation and run in CI.
+/// </summary>
+public class ListValidationTests
+{
+    private static readonly ListCommands Lists = new();
+    private static readonly ThrowingBatch Batch = new();
+
+    [Fact]
+    public void Apply_RejectsStartIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Lists.Apply(Batch, 0));
+
+    [Fact]
+    public void Apply_RejectsUnknownListType()
+        => Assert.Throws<ArgumentException>(() => Lists.Apply(Batch, 1, listType: "squiggle"));
+
+    [Theory]
+    [InlineData("bullet")]
+    [InlineData("number")]
+    [InlineData("outline-number")]
+    public void Apply_AcceptsKnownListTypes(string listType)
+        => Assert.Throws<NotSupportedException>(() => Lists.Apply(Batch, 1, listType: listType));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    public void Apply_RejectsLevelOutsideOneToNine(int level)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Lists.Apply(Batch, 1, level: level));
+
+    [Fact]
+    public void SetLevel_RejectsStartIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Lists.SetLevel(Batch, 0, 1));
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10)]
+    public void SetLevel_RejectsLevelOutsideOneToNine(int level)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Lists.SetLevel(Batch, 1, level));
+
+    [Fact]
+    public void SetLevel_ReachesBatchForValidArguments()
+        => Assert.Throws<NotSupportedException>(() => Lists.SetLevel(Batch, 1, 9));
+
+    [Fact]
+    public void Restart_RejectsStartIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Lists.Restart(Batch, 0));
+
+    [Fact]
+    public void Remove_RejectsStartIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Lists.Remove(Batch, -1));
+
+    [Fact]
+    public void Remove_ReachesBatchForValidArguments()
+        => Assert.Throws<NotSupportedException>(() => Lists.Remove(Batch, 1, 4));
+
+    [Fact]
+    public void AllCommands_RejectNullBatch()
+    {
+        Assert.Throws<ArgumentNullException>(() => Lists.Get(null!));
+        Assert.Throws<ArgumentNullException>(() => Lists.Apply(null!, 1));
+        Assert.Throws<ArgumentNullException>(() => Lists.SetLevel(null!, 1, 1));
+        Assert.Throws<ArgumentNullException>(() => Lists.Restart(null!, 1));
+        Assert.Throws<ArgumentNullException>(() => Lists.Remove(null!, 1));
+    }
+}

--- a/tests/WordMcp.Core.Tests/WordConversionsListTests.cs
+++ b/tests/WordMcp.Core.Tests/WordConversionsListTests.cs
@@ -1,0 +1,44 @@
+using WordMcp.ComInterop;
+using WordMcp.Core.Utilities;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Conversions between the friendly list names on the wire and Word's list constants.
+/// </summary>
+public class WordConversionsListTests
+{
+    [Theory]
+    [InlineData("bullet", ComInteropConstants.WdBulletGallery)]
+    [InlineData("bullets", ComInteropConstants.WdBulletGallery)]
+    [InlineData("number", ComInteropConstants.WdNumberGallery)]
+    [InlineData("numbered", ComInteropConstants.WdNumberGallery)]
+    [InlineData("outline-number", ComInteropConstants.WdOutlineNumberGallery)]
+    [InlineData("outline_number", ComInteropConstants.WdOutlineNumberGallery)]
+    [InlineData("OUTLINE", ComInteropConstants.WdOutlineNumberGallery)]
+    public void ToWdListGallery_MapsKnownNames(string listType, int expected)
+        => Assert.Equal(expected, WordConversions.ToWdListGallery(listType));
+
+    [Fact]
+    public void ToWdListGallery_RejectsUnknownName()
+        => Assert.Throws<ArgumentException>(() => WordConversions.ToWdListGallery("squiggle"));
+
+    [Fact]
+    public void ToWdListGallery_RejectsEmptyName()
+        => Assert.Throws<ArgumentException>(() => WordConversions.ToWdListGallery("  "));
+
+    [Theory]
+    [InlineData(ComInteropConstants.WdListNoNumbering, "none")]
+    [InlineData(ComInteropConstants.WdListBullet, "bullet")]
+    [InlineData(ComInteropConstants.WdListSimpleNumbering, "number")]
+    [InlineData(ComInteropConstants.WdListListNumOnly, "number")]
+    [InlineData(ComInteropConstants.WdListOutlineNumbering, "outline-number")]
+    [InlineData(ComInteropConstants.WdListMixedNumbering, "outline-number")]
+    public void FromWdListType_MapsKnownConstants(int wdListType, string expected)
+        => Assert.Equal(expected, WordConversions.FromWdListType(wdListType));
+
+    [Fact]
+    public void FromWdListType_FallsBackForUnknownConstants()
+        => Assert.Equal("other", WordConversions.FromWdListType(99));
+}


### PR DESCRIPTION
Adds the `list` tool: bullets, numbering, levels and restarting numbering.

## Two Word behaviours that shaped the implementation

**`ListGalleries` hangs off the Application, not the Document.** `doc.ListGalleries` fails at runtime with a late-binding error, which is only visible once a test drives real Word.

**`ApplyTo` decides whether a change hits the range or the whole list.** `restart` re-applies the current list template with `ContinuePreviousList` off, but with `wdListApplyToWholeList` Word keeps the paragraphs in the original list and the numbering just carries on — the restart silently does nothing. `wdListApplyToSelection` is what actually splits the list. The integration test caught this: paragraph 3 still read `3.` instead of `1.`.

## Behaviour worth knowing

- `continue_previous_list` defaults to **false**. Word's own default picks up the numbering of whatever list came before, which surprises callers who just wanted a second list.
- Omitting `end_index` applies the action to `start_index` alone.
- `restart` without an `end_index` covers the rest of the list, because stopping earlier would split it into a third list at that point.
- `set-level` rejects paragraphs that carry no list formatting instead of passing Word's COM error through.
- Only outline-number lists render a distinct format per level; on a plain bullet or number list a deeper level just indents.

## Tests

- 13 validation tests and 11 conversion tests that need no Word, so they run in CI.
- 12 integration tests against real Word: bullets, ascending number labels, nesting an outline list, the restart, removal, and both range guards.
- `GeneratedToolContractTests` picked the new tool up automatically (65 → 69 tests).

Full run: 288 Core tests and 69 McpServer tests green. Release build has 0 warnings.

Closes #22