### PR TITLE
Add comment and revision tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ file(open|create) ──► session_id ──► text / paragraph / table / docu
 
 ## Tools
 
-Eleven tools, each with an `action` parameter.
+Thirteen tools, each with an `action` parameter.
 
 ### `file` — session lifecycle
 
@@ -229,6 +229,44 @@ list(action: "restart", session_id: "...", start_index: 6)
 
 ---
 
+### `comment` — review notes
+
+| Action | Purpose |
+|---|---|
+| `list` | List the comments with author, date, text and the commented-on text |
+| `add` | Attach a comment to a paragraph or to a phrase inside it |
+| `resolve` | Mark a comment as done, or reopen it |
+| `delete` | Remove a comment |
+
+`add` comments the whole paragraph unless `anchor_text` names a phrase inside it. Indexes shift
+after `delete`, so list again before deleting a second comment.
+
+```jsonc
+comment(action: "add", session_id: "...", paragraph_index: 4,
+        text: "Source?", anchor_text: "fifteen percent")
+comment(action: "list", session_id: "...", unresolved_only: true)
+```
+
+---
+
+### `revision` — tracked changes
+
+| Action | Purpose |
+|---|---|
+| `list` | List the tracked changes and report whether tracking is on |
+| `accept` | Accept one revision, or all of them |
+| `reject` | Reject one revision, or all of them |
+| `set-tracking` | Turn change tracking on or off |
+
+Omitting `index` on `accept`/`reject` handles the whole document, headers and footers included.
+
+```jsonc
+revision(action: "set-tracking", session_id: "...", enabled: true)
+revision(action: "accept", session_id: "...")
+```
+
+---
+
 ## Responses
 
 Every tool returns JSON. Failures are reported as structured payloads, never as a transport error:
@@ -268,6 +306,10 @@ Every tool returns JSON. Failures are reported as structured payloads, never as 
 * **`first-page` and `even-pages` headers need a section switch.** `header-footer(set)` turns on `DifferentFirstPage` respectively `DifferentOddEvenPages` for you — without it Word stores the text but never renders it.
 * **`list(apply)` starts a new list by default.** `continue_previous_list` is off, because picking up the numbering of an unrelated earlier list is rarely what was meant. Two numbered lists separated by plain paragraphs stay independent; use `list(restart)` when Word merges them anyway.
 * **Only outline-number lists render distinct levels.** `list(set-level)` works on any list, but a plain `bullet` or `number` list shows the same marker on every level — the paragraphs are merely indented.
+* **`comment(resolve)` often fails on Microsoft 365.** Word's modern comments treat every comment added through the API as an unposted draft, and a draft cannot be marked as done. The server reports that as a clear message; delete the comment instead. `comment(list)` returns `resolved: null` on installations that do not expose the state at all.
+* **Comment and revision indexes shift.** Deleting a comment or accepting a single revision renumbers everything after it, so run `list` again between two such calls instead of reusing the old indexes.
+* **`revision(accept|reject)` without an index also walks headers and footers.** Word's `Document.AcceptAllRevisions()` covers the body only, the same gap as with `field(update-all)`.
+* **Tracked changes are recorded only while tracking is on.** `revision(set-tracking)` does not apply retroactively — turn it on before the edits you want recorded.
 
 ---
 
@@ -288,13 +330,13 @@ dotnet test WordMcp.sln --filter "Category!=RequiresWord"
 | `src/WordMcp.Core` | Command interfaces, command implementations and result models |
 | `src/WordMcp.Generators.Shared` | Source files shared by the generators; not a project of its own |
 | `src/WordMcp.Generators.Mcp` | Roslyn source generator that emits the MCP tool classes |
-| `src/WordMcp.McpServer` | stdio MCP server exposing the eleven tools |
+| `src/WordMcp.McpServer` | stdio MCP server exposing the thirteen tools |
 | `tests/WordMcp.Core.Tests` | Unit tests plus integration tests against a real Word |
 | `tests/WordMcp.McpServer.Tests` | Tool-layer unit tests, no Word required |
 
 ### Generated tool layer
 
-Ten of the eleven tools are generated at build time. The command interfaces in
+Twelve of the thirteen tools are generated at build time. The command interfaces in
 `src/WordMcp.Core/Commands` are the single source of truth for the wire contract:
 
 - `[ServiceCategory("section", "Section")]` names the tool class, `WordSectionTool`.

--- a/src/WordMcp.ComInterop/ComInteropConstants.cs
+++ b/src/WordMcp.ComInterop/ComInteropConstants.cs
@@ -271,6 +271,46 @@ public static class ComInteropConstants
 
     #endregion
 
+    #region Revisions
+
+    /// <summary>WdRevisionType.wdNoRevision = 0.</summary>
+    public const int WdNoRevision = 0;
+
+    /// <summary>WdRevisionType.wdRevisionInsert = 1.</summary>
+    public const int WdRevisionInsert = 1;
+
+    /// <summary>WdRevisionType.wdRevisionDelete = 2.</summary>
+    public const int WdRevisionDelete = 2;
+
+    /// <summary>WdRevisionType.wdRevisionProperty = 3.</summary>
+    public const int WdRevisionProperty = 3;
+
+    /// <summary>WdRevisionType.wdRevisionStyle = 8.</summary>
+    public const int WdRevisionStyle = 8;
+
+    /// <summary>WdRevisionType.wdRevisionReplace = 9.</summary>
+    public const int WdRevisionReplace = 9;
+
+    /// <summary>WdRevisionType.wdRevisionParagraphProperty = 10.</summary>
+    public const int WdRevisionParagraphProperty = 10;
+
+    /// <summary>WdRevisionType.wdRevisionTableProperty = 11.</summary>
+    public const int WdRevisionTableProperty = 11;
+
+    /// <summary>WdRevisionType.wdRevisionSectionProperty = 12.</summary>
+    public const int WdRevisionSectionProperty = 12;
+
+    /// <summary>WdRevisionType.wdRevisionStyleDefinition = 13.</summary>
+    public const int WdRevisionStyleDefinition = 13;
+
+    /// <summary>WdRevisionType.wdRevisionMovedFrom = 14.</summary>
+    public const int WdRevisionMovedFrom = 14;
+
+    /// <summary>WdRevisionType.wdRevisionMovedTo = 15.</summary>
+    public const int WdRevisionMovedTo = 15;
+
+    #endregion
+
     #region Supported extensions
 
     /// <summary>

--- a/src/WordMcp.Core/Commands/Comment/CommentCommands.cs
+++ b/src/WordMcp.Core/Commands/Comment/CommentCommands.cs
@@ -1,0 +1,243 @@
+using System.Runtime.InteropServices;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.Comment;
+
+/// <summary>
+/// Word COM implementation of <see cref="ICommentCommands"/>.
+/// </summary>
+public sealed class CommentCommands : ICommentCommands
+{
+    /// <inheritdoc />
+    public CommentListResult List(IWordBatch batch, bool unresolvedOnly = false)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic comments = doc.Comments;
+            int total = (int)comments.Count;
+
+            var list = new List<CommentInfo>();
+
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var info = Describe(comments[i], i);
+                if (unresolvedOnly && info.Resolved == true)
+                    continue;
+
+                list.Add(info);
+            }
+
+            return new CommentListResult
+            {
+                TotalCount = total,
+                Comments = list
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public CommentResult Add(IWordBatch batch, int paragraphIndex, string text, string? anchorText = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+        ArgumentOutOfRangeException.ThrowIfLessThan(paragraphIndex, 1);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            int paragraphs = (int)doc.Paragraphs.Count;
+
+            if (paragraphIndex > paragraphs)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(paragraphIndex),
+                    $"Paragraph {paragraphIndex} does not exist. The document has {paragraphs} paragraph(s).");
+            }
+
+            dynamic paragraph = doc.Paragraphs[paragraphIndex];
+            dynamic range = Anchor(doc, paragraph, paragraphIndex, anchorText);
+
+            dynamic comment = doc.Comments.Add(range, text);
+            int index = (int)comment.Index;
+
+            return new CommentResult
+            {
+                Comment = Describe(comment, index),
+                TotalCount = (int)doc.Comments.Count,
+                Message = $"Comment {index} added to paragraph {paragraphIndex}."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public CommentResult Resolve(IWordBatch batch, int index, bool resolved = true)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(index, 1);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic comment = Require(doc, index);
+
+            try
+            {
+                comment.Done = resolved;
+            }
+            catch (COMException ex)
+            {
+                // Two cases end up here and both surface as "command is not available": Word before
+                // 2013 has no Done property at all, and modern comments refuse it for a comment that
+                // was never posted in the UI - which includes every comment added through this API.
+                throw new NotSupportedException(
+                    $"Word refused to change the resolved state of comment {index}. Comments added " +
+                    "through the API are drafts that modern comments cannot resolve, and Word " +
+                    "versions before 2013 do not support resolving at all. Delete the comment instead.",
+                    ex);
+            }
+
+            return new CommentResult
+            {
+                Comment = Describe(comment, index),
+                TotalCount = (int)doc.Comments.Count,
+                Message = resolved ? $"Comment {index} resolved." : $"Comment {index} reopened."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public CommentResult Delete(IWordBatch batch, int index)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(index, 1);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            Require(doc, index).Delete();
+
+            return new CommentResult
+            {
+                TotalCount = (int)doc.Comments.Count,
+                Message = $"Comment {index} deleted."
+            };
+        });
+    }
+
+    private static dynamic Require(dynamic doc, int index)
+    {
+        int total = (int)doc.Comments.Count;
+
+        if (index > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(index), $"Comment {index} does not exist. The document has {total} comment(s).");
+        }
+
+        return doc.Comments[index];
+    }
+
+    /// <summary>
+    /// Resolves the range a comment attaches to: the whole paragraph, or the phrase inside it.
+    /// </summary>
+    private static dynamic Anchor(dynamic doc, dynamic paragraph, int paragraphIndex, string? anchorText)
+    {
+        if (string.IsNullOrEmpty(anchorText))
+        {
+            return paragraph.Range;
+        }
+
+        string paragraphText = WordConversions.CleanRangeText((string?)paragraph.Range.Text);
+        int offset = paragraphText.IndexOf(anchorText, StringComparison.Ordinal);
+
+        if (offset < 0)
+        {
+            throw new ArgumentException(
+                $"Paragraph {paragraphIndex} does not contain '{anchorText}'.", nameof(anchorText));
+        }
+
+        int start = (int)paragraph.Range.Start + offset;
+        return doc.Range(start, start + anchorText.Length);
+    }
+
+    private static CommentInfo Describe(dynamic comment, int index)
+    {
+        var info = new CommentInfo
+        {
+            Index = index,
+            Author = (string?)comment.Author ?? string.Empty,
+            Initial = (string?)comment.Initial ?? string.Empty,
+            Text = WordConversions.CleanRangeText((string?)comment.Range.Text),
+            Date = ReadDate(comment),
+            Resolved = ReadResolved(comment)
+        };
+
+        try
+        {
+            dynamic scope = comment.Scope;
+            info.ScopeText = WordConversions.CleanRangeText((string?)scope.Text);
+            info.ParagraphIndex = ParagraphIndexOf(comment, scope);
+        }
+        catch (COMException)
+        {
+            // A comment whose anchor was deleted still exists but has no usable scope.
+        }
+
+        return info;
+    }
+
+    private static int ParagraphIndexOf(dynamic comment, dynamic scope)
+    {
+        try
+        {
+            dynamic doc = comment.Parent;
+            int start = (int)scope.Start;
+            int count = (int)doc.Paragraphs.Count;
+
+            for (int i = 1; i <= count; i++)
+            {
+                dynamic range = doc.Paragraphs[i].Range;
+                if (start >= (int)range.Start && start < (int)range.End)
+                    return i;
+            }
+        }
+        catch (COMException)
+        {
+            // Falling back to 0 keeps the rest of the comment usable.
+        }
+
+        return 0;
+    }
+
+    private static DateTime? ReadDate(dynamic comment)
+    {
+        try
+        {
+            return (DateTime)comment.Date;
+        }
+        catch (COMException)
+        {
+            return null;
+        }
+    }
+
+    private static bool? ReadResolved(dynamic comment)
+    {
+        try
+        {
+            return (bool)comment.Done;
+        }
+        catch (COMException)
+        {
+            // Word versions before 2013 have no resolved state at all.
+            return null;
+        }
+    }
+}

--- a/src/WordMcp.Core/Commands/Comment/ICommentCommands.cs
+++ b/src/WordMcp.Core/Commands/Comment/ICommentCommands.cs
@@ -1,0 +1,69 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Comment;
+
+/// <summary>
+/// Comment operations: listing, adding, resolving and deleting comments.
+/// </summary>
+[ServiceCategory("comment", "Comment")]
+[McpTool("comment",
+    Title = "Comment Operations",
+    Description = "Comment operations on an open document, the basis for review workflows. "
+        + "comment(list, session_id) returns every comment with its author, date, text and the "
+        + "document text it refers to. "
+        + "comment(add, session_id, paragraph_index=3, text='Please shorten this') attaches a "
+        + "comment to a whole paragraph; pass anchor_text to attach it to a phrase inside that "
+        + "paragraph instead. "
+        + "comment(resolve, session_id, index=1) marks a comment as done; pass resolved=false to "
+        + "reopen it. "
+        + "comment(delete, session_id, index=1) removes a comment. "
+        + "Comment indexes are 1-based and shift after every delete, so when removing several "
+        + "comments work from the highest index downwards. "
+        + "Paragraph indexes come from paragraph(list).")]
+public interface ICommentCommands
+{
+    /// <summary>
+    /// Lists the comments of the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="unresolvedOnly">
+    /// Whether to return only comments that are not marked as resolved. Defaults to false.
+    /// </param>
+    /// <returns>The matching comments.</returns>
+    [ServiceAction("list")]
+    CommentListResult List(IWordBatch batch, bool unresolvedOnly = false);
+
+    /// <summary>
+    /// Adds a comment to a paragraph or to a phrase inside it.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="paragraphIndex">1-based index of the paragraph to comment on.</param>
+    /// <param name="text">The comment text.</param>
+    /// <param name="anchorText">
+    /// A phrase inside the paragraph the comment should attach to. The whole paragraph when omitted.
+    /// </param>
+    /// <returns>The created comment.</returns>
+    [ServiceAction("add")]
+    CommentResult Add(IWordBatch batch, int paragraphIndex, string text, string? anchorText = null);
+
+    /// <summary>
+    /// Marks a comment as resolved or reopens it.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based index of the comment.</param>
+    /// <param name="resolved">Whether the comment is resolved. Defaults to true.</param>
+    /// <returns>The changed comment.</returns>
+    [ServiceAction("resolve")]
+    CommentResult Resolve(IWordBatch batch, int index, bool resolved = true);
+
+    /// <summary>
+    /// Deletes a comment.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based index of the comment.</param>
+    /// <returns>The number of comments left.</returns>
+    [ServiceAction("delete")]
+    CommentResult Delete(IWordBatch batch, int index);
+}

--- a/src/WordMcp.Core/Commands/Revision/IRevisionCommands.cs
+++ b/src/WordMcp.Core/Commands/Revision/IRevisionCommands.cs
@@ -1,0 +1,62 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Revision;
+
+/// <summary>
+/// Revision operations: listing, accepting and rejecting tracked changes.
+/// </summary>
+[ServiceCategory("revision", "Revision")]
+[McpTool("revision",
+    Title = "Revision Operations",
+    Description = "Tracked change operations on an open document. "
+        + "revision(list, session_id) returns every tracked change with its type, author, date and "
+        + "affected text, plus whether tracking is currently on. "
+        + "revision(accept, session_id) accepts every change; pass index=1 to accept a single one. "
+        + "revision(reject, session_id, index=2) discards a change the same way. "
+        + "revision(set-tracking, session_id, enabled=true) turns change tracking on or off, which "
+        + "is what makes later edits show up as revisions in the first place. "
+        + "Revision indexes are 1-based and shift after every accept or reject, so when handling "
+        + "several changes individually work from the highest index downwards, or just accept or "
+        + "reject them all at once. "
+        + "Accepting or rejecting everything also covers headers and footers, which Word's own "
+        + "AcceptAllRevisions does not.")]
+public interface IRevisionCommands
+{
+    /// <summary>
+    /// Lists the tracked changes of the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="author">Restrict the result to one author. All authors when omitted.</param>
+    /// <returns>The matching changes.</returns>
+    [ServiceAction("list")]
+    RevisionListResult List(IWordBatch batch, string? author = null);
+
+    /// <summary>
+    /// Accepts one tracked change, or all of them.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based index of the change. All changes when omitted.</param>
+    /// <returns>The number of changes accepted.</returns>
+    [ServiceAction("accept")]
+    RevisionResult Accept(IWordBatch batch, int? index = null);
+
+    /// <summary>
+    /// Rejects one tracked change, or all of them.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based index of the change. All changes when omitted.</param>
+    /// <returns>The number of changes rejected.</returns>
+    [ServiceAction("reject")]
+    RevisionResult Reject(IWordBatch batch, int? index = null);
+
+    /// <summary>
+    /// Turns change tracking on or off.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="enabled">Whether edits are recorded as tracked changes.</param>
+    /// <returns>The tracking state after the change.</returns>
+    [ServiceAction("set-tracking")]
+    RevisionResult SetTracking(IWordBatch batch, bool enabled);
+}

--- a/src/WordMcp.Core/Commands/Revision/RevisionCommands.cs
+++ b/src/WordMcp.Core/Commands/Revision/RevisionCommands.cs
@@ -1,0 +1,198 @@
+using System.Runtime.InteropServices;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.Revision;
+
+/// <summary>
+/// Word COM implementation of <see cref="IRevisionCommands"/>.
+/// </summary>
+public sealed class RevisionCommands : IRevisionCommands
+{
+    /// <inheritdoc />
+    public RevisionListResult List(IWordBatch batch, string? author = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic revisions = doc.Revisions;
+            int total = (int)revisions.Count;
+
+            var list = new List<RevisionInfo>();
+
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var info = Describe(revisions[i], i);
+
+                if (author is not null
+                    && !string.Equals(info.Author, author, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                list.Add(info);
+            }
+
+            return new RevisionListResult
+            {
+                TotalCount = total,
+                TrackingEnabled = (bool)doc.TrackRevisions,
+                Revisions = list
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public RevisionResult Accept(IWordBatch batch, int? index = null)
+        => Handle(batch, index, accept: true);
+
+    /// <inheritdoc />
+    public RevisionResult Reject(IWordBatch batch, int? index = null)
+        => Handle(batch, index, accept: false);
+
+    /// <inheritdoc />
+    public RevisionResult SetTracking(IWordBatch batch, bool enabled)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            doc.TrackRevisions = enabled;
+
+            return new RevisionResult
+            {
+                HandledCount = 0,
+                TotalCount = (int)doc.Revisions.Count,
+                TrackingEnabled = (bool)doc.TrackRevisions,
+                Message = enabled ? "Change tracking turned on." : "Change tracking turned off."
+            };
+        });
+    }
+
+    private static RevisionResult Handle(IWordBatch batch, int? index, bool accept)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+
+        if (index is < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(index), index, "index must be 1 or greater.");
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            string verb = accept ? "accepted" : "rejected";
+            int handled;
+
+            if (index.HasValue)
+            {
+                int total = (int)doc.Revisions.Count;
+                if (index.Value > total)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(index),
+                        $"Revision {index.Value} does not exist. The document has {total} tracked change(s).");
+                }
+
+                dynamic revision = doc.Revisions[index.Value];
+                if (accept)
+                    revision.Accept();
+                else
+                    revision.Reject();
+
+                handled = 1;
+            }
+            else
+            {
+                handled = (int)doc.Revisions.Count;
+
+                if (accept)
+                    doc.AcceptAllRevisions();
+                else
+                    doc.RejectAllRevisions();
+
+                // Document.Revisions covers the body only, the same blind spot field(update-all)
+                // works around.
+                foreach (dynamic section in doc.Sections)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    handled += HandleHeaderFooter(section.Headers, accept);
+                    handled += HandleHeaderFooter(section.Footers, accept);
+                }
+            }
+
+            return new RevisionResult
+            {
+                HandledCount = handled,
+                TotalCount = (int)doc.Revisions.Count,
+                TrackingEnabled = (bool)doc.TrackRevisions,
+                Message = index.HasValue
+                    ? $"Revision {index.Value} {verb}."
+                    : $"{handled} tracked change(s) {verb}."
+            };
+        });
+    }
+
+    private static int HandleHeaderFooter(dynamic headersOrFooters, bool accept)
+    {
+        int handled = 0;
+
+        foreach (dynamic entry in headersOrFooters)
+        {
+            dynamic revisions = entry.Range.Revisions;
+            int count = (int)revisions.Count;
+
+            if (count == 0)
+                continue;
+
+            handled += count;
+
+            if (accept)
+                revisions.AcceptAll();
+            else
+                revisions.RejectAll();
+        }
+
+        return handled;
+    }
+
+    private static RevisionInfo Describe(dynamic revision, int index)
+    {
+        var info = new RevisionInfo
+        {
+            Index = index,
+            Type = WordConversions.FromWdRevisionType((int)revision.Type),
+            Author = (string?)revision.Author ?? string.Empty,
+            Date = ReadDate(revision)
+        };
+
+        try
+        {
+            info.Text = WordConversions.CleanRangeText((string?)revision.Range.Text);
+        }
+        catch (COMException)
+        {
+            // Formatting revisions have no text of their own.
+        }
+
+        return info;
+    }
+
+    private static DateTime? ReadDate(dynamic revision)
+    {
+        try
+        {
+            return (DateTime)revision.Date;
+        }
+        catch (COMException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/WordMcp.Core/Models/CommentResults.cs
+++ b/src/WordMcp.Core/Models/CommentResults.cs
@@ -1,0 +1,61 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Metadata for a single comment of a document.
+/// </summary>
+public sealed class CommentInfo
+{
+    /// <summary>Gets or sets the 1-based comment index.</summary>
+    public int Index { get; set; }
+
+    /// <summary>Gets or sets the author name.</summary>
+    public string Author { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the author initials.</summary>
+    public string Initial { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the date the comment was written.</summary>
+    public DateTime? Date { get; set; }
+
+    /// <summary>Gets or sets the comment text.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the document text the comment refers to.</summary>
+    public string ScopeText { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets whether the comment is marked as resolved, or null on a Word version that does
+    /// not support resolving comments.
+    /// </summary>
+    public bool? Resolved { get; set; }
+
+    /// <summary>
+    /// Gets or sets the 1-based index of the paragraph the comment refers to, or 0 when it could
+    /// not be determined.
+    /// </summary>
+    public int ParagraphIndex { get; set; }
+}
+
+/// <summary>
+/// The comments of a document.
+/// </summary>
+public sealed class CommentListResult : ResultBase
+{
+    /// <summary>Gets or sets the number of comments in the document.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets the comments.</summary>
+    public IReadOnlyList<CommentInfo> Comments { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation that adds, resolves or removes a comment.
+/// </summary>
+public sealed class CommentResult : ResultBase
+{
+    /// <summary>Gets or sets the affected comment, when it still exists.</summary>
+    public CommentInfo? Comment { get; set; }
+
+    /// <summary>Gets or sets the number of comments left in the document.</summary>
+    public int TotalCount { get; set; }
+}

--- a/src/WordMcp.Core/Models/RevisionResults.cs
+++ b/src/WordMcp.Core/Models/RevisionResults.cs
@@ -1,0 +1,55 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Metadata for a single tracked change of a document.
+/// </summary>
+public sealed class RevisionInfo
+{
+    /// <summary>Gets or sets the 1-based revision index.</summary>
+    public int Index { get; set; }
+
+    /// <summary>
+    /// Gets or sets the kind of change: <c>insert</c>, <c>delete</c>, <c>format</c>,
+    /// <c>moved-from</c>, <c>moved-to</c> or <c>other</c>.
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the author of the change.</summary>
+    public string Author { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the date of the change.</summary>
+    public DateTime? Date { get; set; }
+
+    /// <summary>Gets or sets the affected text.</summary>
+    public string Text { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// The tracked changes of a document.
+/// </summary>
+public sealed class RevisionListResult : ResultBase
+{
+    /// <summary>Gets or sets the number of tracked changes in the document.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets whether change tracking is currently on.</summary>
+    public bool TrackingEnabled { get; set; }
+
+    /// <summary>Gets or sets the tracked changes.</summary>
+    public IReadOnlyList<RevisionInfo> Revisions { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation that accepts or rejects changes, or switches tracking.
+/// </summary>
+public sealed class RevisionResult : ResultBase
+{
+    /// <summary>Gets or sets the number of changes the operation handled.</summary>
+    public int HandledCount { get; set; }
+
+    /// <summary>Gets or sets the number of tracked changes left in the document.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets whether change tracking is on after the operation.</summary>
+    public bool TrackingEnabled { get; set; }
+}

--- a/src/WordMcp.Core/Utilities/WordConversions.cs
+++ b/src/WordMcp.Core/Utilities/WordConversions.cs
@@ -328,6 +328,28 @@ public static class WordConversions
         _ => "other"
     };
 
+    /// <summary>
+    /// Converts a <c>WdRevisionType</c> value to its friendly name.
+    /// </summary>
+    /// <param name="wdRevisionType">The Word revision type constant.</param>
+    /// <returns>The friendly change kind name.</returns>
+    public static string FromWdRevisionType(int wdRevisionType) => wdRevisionType switch
+    {
+        ComInteropConstants.WdNoRevision => "none",
+        ComInteropConstants.WdRevisionInsert => "insert",
+        ComInteropConstants.WdRevisionDelete => "delete",
+        ComInteropConstants.WdRevisionReplace => "replace",
+        ComInteropConstants.WdRevisionMovedFrom => "moved-from",
+        ComInteropConstants.WdRevisionMovedTo => "moved-to",
+        ComInteropConstants.WdRevisionProperty
+            or ComInteropConstants.WdRevisionStyle
+            or ComInteropConstants.WdRevisionParagraphProperty
+            or ComInteropConstants.WdRevisionTableProperty
+            or ComInteropConstants.WdRevisionSectionProperty
+            or ComInteropConstants.WdRevisionStyleDefinition => "format",
+        _ => "other"
+    };
+
     private static string NormalizeName(string value)
         => value.Trim().ToLowerInvariant().Replace('_', '-').Replace(" ", string.Empty, StringComparison.Ordinal);
 }

--- a/src/WordMcp.McpServer/WordServices.cs
+++ b/src/WordMcp.McpServer/WordServices.cs
@@ -1,11 +1,13 @@
 using Microsoft.Extensions.Logging;
 using WordMcp.ComInterop.Session;
 using WordMcp.Core.Commands.Document;
+using WordMcp.Core.Commands.Comment;
 using WordMcp.Core.Commands.Field;
 using WordMcp.Core.Commands.HeaderFooter;
 using WordMcp.Core.Commands.Image;
 using WordMcp.Core.Commands.List;
 using WordMcp.Core.Commands.Paragraph;
+using WordMcp.Core.Commands.Revision;
 using WordMcp.Core.Commands.Section;
 using WordMcp.Core.Commands.Style;
 using WordMcp.Core.Commands.Table;
@@ -69,6 +71,12 @@ internal static class WordServices
 
     /// <summary>Gets the list command implementation.</summary>
     public static IListCommands Lists { get; } = new ListCommands();
+
+    /// <summary>Gets the comment command implementation.</summary>
+    public static ICommentCommands Comments { get; } = new CommentCommands();
+
+    /// <summary>Gets the revision command implementation.</summary>
+    public static IRevisionCommands Revisions { get; } = new RevisionCommands();
 
     /// <summary>
     /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.

--- a/tests/WordMcp.Core.Tests/CommentAndRevisionIntegrationTests.cs
+++ b/tests/WordMcp.Core.Tests/CommentAndRevisionIntegrationTests.cs
@@ -1,0 +1,216 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.Comment;
+using WordMcp.Core.Commands.Paragraph;
+using WordMcp.Core.Commands.Revision;
+using WordMcp.Core.Commands.Text;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Integration tests for the comment and revision commands. They use their own document because
+/// change tracking is document-wide state.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class CommentAndRevisionIntegrationTests : IDisposable
+{
+    private static readonly CommentCommands Comments = new();
+    private static readonly RevisionCommands Revisions = new();
+    private static readonly ParagraphCommands Paragraphs = new();
+    private static readonly TextCommands Texts = new();
+
+    private readonly SessionManager _sessions = new();
+    private readonly string _directory;
+    private readonly string _sessionId;
+
+    private IWordBatch Batch => _sessions.GetBatch(_sessionId);
+
+    public CommentAndRevisionIntegrationTests()
+    {
+        _directory = Directory
+            .CreateDirectory(Path.Combine(Path.GetTempPath(), "wordmcp-review-" + Guid.NewGuid().ToString("N")))
+            .FullName;
+
+        _sessionId = _sessions.Create(Path.Combine(_directory, "review.docx")).SessionId;
+    }
+
+    [Fact]
+    public void Comment_AddListAndDeleteRoundTrip()
+    {
+        int index = Paragraphs.Add(Batch, "The quick brown fox jumps.").Paragraph!.Index;
+
+        var added = Comments.Add(Batch, index, "Please shorten this sentence.");
+
+        Assert.Equal(1, added.TotalCount);
+        Assert.Equal("Please shorten this sentence.", added.Comment!.Text);
+        Assert.Contains("quick brown fox", added.Comment.ScopeText, StringComparison.Ordinal);
+
+        var list = Comments.List(Batch);
+        Assert.Equal(1, list.TotalCount);
+        Assert.Equal(index, list.Comments[0].ParagraphIndex);
+        Assert.False(string.IsNullOrWhiteSpace(list.Comments[0].Author));
+
+        var deleted = Comments.Delete(Batch, 1);
+        Assert.Equal(0, deleted.TotalCount);
+        Assert.Empty(Comments.List(Batch).Comments);
+    }
+
+    [Fact]
+    public void Comment_AnchorTextNarrowsTheScope()
+    {
+        int index = Paragraphs.Add(Batch, "Revenue grew by fifteen percent last year.").Paragraph!.Index;
+
+        var added = Comments.Add(Batch, index, "Source?", "fifteen percent");
+
+        Assert.Equal("fifteen percent", added.Comment!.ScopeText);
+    }
+
+    [Fact]
+    public void Comment_AddRejectsAnchorTextThatIsNotInTheParagraph()
+    {
+        int index = Paragraphs.Add(Batch, "A short sentence.").Paragraph!.Index;
+
+        Assert.Throws<ArgumentException>(() => Comments.Add(Batch, index, "Note", "not present"));
+    }
+
+    [Fact]
+    public void Comment_AddRejectsMissingParagraph()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Comments.Add(Batch, 500, "Note"));
+
+    [Fact]
+    public void Comment_ResolveEitherMarksTheCommentOrReportsItAsUnsupported()
+    {
+        int index = Paragraphs.Add(Batch, "Draft wording.").Paragraph!.Index;
+        Comments.Add(Batch, index, "Needs review.");
+
+        // Modern comments treat everything added through the API as an unposted draft and refuse to
+        // resolve it, so both outcomes are correct as long as the failure is a clear message.
+        try
+        {
+            var resolved = Comments.Resolve(Batch, 1);
+
+            Assert.True(resolved.Comment!.Resolved);
+            Assert.Empty(Comments.List(Batch, unresolvedOnly: true).Comments);
+
+            var reopened = Comments.Resolve(Batch, 1, resolved: false);
+            Assert.False(reopened.Comment!.Resolved);
+            Assert.Single(Comments.List(Batch, unresolvedOnly: true).Comments);
+        }
+        catch (NotSupportedException ex)
+        {
+            Assert.Contains("Delete the comment instead", ex.Message, StringComparison.Ordinal);
+            Assert.Single(Comments.List(Batch, unresolvedOnly: true).Comments);
+        }
+    }
+
+    [Fact]
+    public void Comment_RejectsMissingComment()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Comments.Delete(Batch, 7));
+
+    [Fact]
+    public void Revision_TrackingIsOffForANewDocument()
+    {
+        var list = Revisions.List(Batch);
+
+        Assert.False(list.TrackingEnabled);
+        Assert.Equal(0, list.TotalCount);
+    }
+
+    [Fact]
+    public void Revision_EditsAreRecordedWhileTrackingIsOn()
+    {
+        Paragraphs.Add(Batch, "Original wording stays.");
+
+        var enabled = Revisions.SetTracking(Batch, true);
+        Assert.True(enabled.TrackingEnabled);
+
+        Texts.Replace(Batch, "Original", "Revised");
+
+        var list = Revisions.List(Batch);
+        Assert.True(list.TrackingEnabled);
+        Assert.True(list.TotalCount > 0);
+        Assert.Contains(list.Revisions, r => r.Type is "insert" or "delete" or "replace");
+        Assert.All(list.Revisions, r => Assert.False(string.IsNullOrWhiteSpace(r.Author)));
+    }
+
+    [Fact]
+    public void Revision_AcceptAllClearsTheChanges()
+    {
+        Paragraphs.Add(Batch, "Original wording stays.");
+        Revisions.SetTracking(Batch, true);
+        Texts.Replace(Batch, "Original", "Revised");
+
+        var accepted = Revisions.Accept(Batch);
+
+        Assert.True(accepted.HandledCount > 0);
+        Assert.Equal(0, accepted.TotalCount);
+        Assert.Contains("Revised", Texts.Get(Batch).Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Revision_RejectAllRestoresTheOriginalText()
+    {
+        Paragraphs.Add(Batch, "Original wording stays.");
+        Revisions.SetTracking(Batch, true);
+        Texts.Replace(Batch, "Original", "Revised");
+
+        var rejected = Revisions.Reject(Batch);
+
+        Assert.Equal(0, rejected.TotalCount);
+
+        string text = Texts.Get(Batch).Text;
+        Assert.Contains("Original", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Revised", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Revision_AcceptOneLeavesTheOthers()
+    {
+        Paragraphs.Add(Batch, "Alpha stays here.");
+        Paragraphs.Add(Batch, "Beta stays here.");
+        Revisions.SetTracking(Batch, true);
+        Texts.Replace(Batch, "Alpha", "Gamma");
+        Texts.Replace(Batch, "Beta", "Delta");
+
+        int before = Revisions.List(Batch).TotalCount;
+        Assert.True(before > 1);
+
+        var accepted = Revisions.Accept(Batch, 1);
+
+        Assert.Equal(1, accepted.HandledCount);
+        Assert.Equal(before - 1, accepted.TotalCount);
+    }
+
+    [Fact]
+    public void Revision_RejectsMissingRevision()
+    {
+        Revisions.SetTracking(Batch, true);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Revisions.Accept(Batch, 9));
+    }
+
+    [Fact]
+    public void Revision_TrackingCanBeTurnedOffAgain()
+    {
+        Revisions.SetTracking(Batch, true);
+
+        var disabled = Revisions.SetTracking(Batch, false);
+
+        Assert.False(disabled.TrackingEnabled);
+        Assert.False(Revisions.List(Batch).TrackingEnabled);
+    }
+
+    public void Dispose()
+    {
+        _sessions.Dispose();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A locked temp file must not fail the test run.
+        }
+    }
+}

--- a/tests/WordMcp.Core.Tests/CommentAndRevisionValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/CommentAndRevisionValidationTests.cs
@@ -1,0 +1,74 @@
+using WordMcp.Core.Commands.Comment;
+using WordMcp.Core.Commands.Revision;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Argument validation of the comment and revision commands. Everything asserted here happens
+/// before the batch is touched, so these tests need no Word installation and run in CI.
+/// </summary>
+public class CommentAndRevisionValidationTests
+{
+    private static readonly CommentCommands Comments = new();
+    private static readonly RevisionCommands Revisions = new();
+    private static readonly ThrowingBatch Batch = new();
+
+    [Fact]
+    public void Comment_AddRejectsParagraphIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Comments.Add(Batch, 0, "Note"));
+
+    [Fact]
+    public void Comment_AddRejectsEmptyText()
+        => Assert.Throws<ArgumentException>(() => Comments.Add(Batch, 1, "   "));
+
+    [Fact]
+    public void Comment_AddReachesBatchForValidArguments()
+        => Assert.Throws<NotSupportedException>(() => Comments.Add(Batch, 1, "Note", "anchor"));
+
+    [Fact]
+    public void Comment_ResolveRejectsIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Comments.Resolve(Batch, 0));
+
+    [Fact]
+    public void Comment_DeleteRejectsIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Comments.Delete(Batch, -3));
+
+    [Fact]
+    public void Comment_AllCommandsRejectNullBatch()
+    {
+        Assert.Throws<ArgumentNullException>(() => Comments.List(null!));
+        Assert.Throws<ArgumentNullException>(() => Comments.Add(null!, 1, "Note"));
+        Assert.Throws<ArgumentNullException>(() => Comments.Resolve(null!, 1));
+        Assert.Throws<ArgumentNullException>(() => Comments.Delete(null!, 1));
+    }
+
+    [Fact]
+    public void Revision_AcceptRejectsIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Revisions.Accept(Batch, 0));
+
+    [Fact]
+    public void Revision_RejectRejectsIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Revisions.Reject(Batch, 0));
+
+    [Fact]
+    public void Revision_AcceptWithoutIndexReachesBatch()
+        => Assert.Throws<NotSupportedException>(() => Revisions.Accept(Batch));
+
+    [Fact]
+    public void Revision_RejectWithoutIndexReachesBatch()
+        => Assert.Throws<NotSupportedException>(() => Revisions.Reject(Batch));
+
+    [Fact]
+    public void Revision_SetTrackingReachesBatch()
+        => Assert.Throws<NotSupportedException>(() => Revisions.SetTracking(Batch, true));
+
+    [Fact]
+    public void Revision_AllCommandsRejectNullBatch()
+    {
+        Assert.Throws<ArgumentNullException>(() => Revisions.List(null!));
+        Assert.Throws<ArgumentNullException>(() => Revisions.Accept(null!));
+        Assert.Throws<ArgumentNullException>(() => Revisions.Reject(null!));
+        Assert.Throws<ArgumentNullException>(() => Revisions.SetTracking(null!, true));
+    }
+}

--- a/tests/WordMcp.Core.Tests/WordConversionsRevisionTests.cs
+++ b/tests/WordMcp.Core.Tests/WordConversionsRevisionTests.cs
@@ -1,0 +1,35 @@
+using WordMcp.ComInterop;
+using WordMcp.Core.Utilities;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Conversion of Word's revision type constants to the friendly names on the wire.
+/// </summary>
+public class WordConversionsRevisionTests
+{
+    [Theory]
+    [InlineData(ComInteropConstants.WdNoRevision, "none")]
+    [InlineData(ComInteropConstants.WdRevisionInsert, "insert")]
+    [InlineData(ComInteropConstants.WdRevisionDelete, "delete")]
+    [InlineData(ComInteropConstants.WdRevisionReplace, "replace")]
+    [InlineData(ComInteropConstants.WdRevisionMovedFrom, "moved-from")]
+    [InlineData(ComInteropConstants.WdRevisionMovedTo, "moved-to")]
+    public void FromWdRevisionType_MapsDistinctKinds(int wdRevisionType, string expected)
+        => Assert.Equal(expected, WordConversions.FromWdRevisionType(wdRevisionType));
+
+    [Theory]
+    [InlineData(ComInteropConstants.WdRevisionProperty)]
+    [InlineData(ComInteropConstants.WdRevisionStyle)]
+    [InlineData(ComInteropConstants.WdRevisionParagraphProperty)]
+    [InlineData(ComInteropConstants.WdRevisionTableProperty)]
+    [InlineData(ComInteropConstants.WdRevisionSectionProperty)]
+    [InlineData(ComInteropConstants.WdRevisionStyleDefinition)]
+    public void FromWdRevisionType_CollapsesFormattingKinds(int wdRevisionType)
+        => Assert.Equal("format", WordConversions.FromWdRevisionType(wdRevisionType));
+
+    [Fact]
+    public void FromWdRevisionType_FallsBackForUnknownConstants()
+        => Assert.Equal("other", WordConversions.FromWdRevisionType(99));
+}


### PR DESCRIPTION
Adds the two review tools from #23.

### `comment`

| Action | Purpose |
|---|---|
| `list` | Comments with author, date, text, commented-on text and paragraph index |
| `add` | Attach a comment to a paragraph, or to a phrase inside it via `anchor_text` |
| `resolve` | Mark a comment as done, or reopen it |
| `delete` | Remove a comment |

### `revision`

| Action | Purpose |
|---|---|
| `list` | Tracked changes plus whether tracking is on |
| `accept` | Accept one revision, or all of them |
| `reject` | Reject one revision, or all of them |
| `set-tracking` | Turn change tracking on or off |

### Notes

- `revision(accept|reject)` without an index also walks headers and footers. Word's `AcceptAllRevisions()` covers the body only - the same gap already handled for `field(update-all)`.
- **`comment(resolve)` frequently fails on Microsoft 365.** Modern comments treat every comment added through the API as an unposted draft and refuse to mark it done. The server turns that COM error into a `NotSupportedException` explaining the situation; the integration test accepts either outcome so it stays honest across Word versions.
- Both tools are generated from their interfaces by the Roslyn generator, so only the interface, the COM implementation and the `WordServices` property were written by hand.

### Verification

- Release build: 0 warnings, 0 errors
- Full run: **326 Core + 77 McpServer = 403 tests green**, including 13 new Word integration tests

Refs #23
