### PR TITLE
Add the bookmark tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ file(open|create) ──► session_id ──► text / paragraph / table / docu
 
 ## Tools
 
-Thirteen tools, each with an `action` parameter.
+Fourteen tools, each with an `action` parameter.
 
 ### `file` — session lifecycle
 
@@ -267,6 +267,28 @@ revision(action: "accept", session_id: "...")
 
 ---
 
+### `bookmark` — stable references
+
+| Action | Purpose |
+|---|---|
+| `list` | Bookmarks with name, paragraph index and a preview of the marked text |
+| `add` | Bookmark a paragraph, a paragraph range or a phrase inside a paragraph |
+| `get-text` | Read the full bookmarked text |
+| `delete` | Remove a bookmark; the text stays |
+
+Names must start with a letter and may only contain letters, digits and underscores. Bookmarks
+survive edits elsewhere in the document, which makes them the reliable way to refer back to a
+passage once paragraph indexes have shifted.
+
+```jsonc
+bookmark(action: "add", session_id: "...", name: "Intro", paragraph_index: 2)
+bookmark(action: "add", session_id: "...", name: "Growth",
+         paragraph_index: 4, anchor_text: "fifteen percent")
+bookmark(action: "get-text", session_id: "...", name: "Intro")
+```
+
+---
+
 ## Responses
 
 Every tool returns JSON. Failures are reported as structured payloads, never as a transport error:
@@ -310,6 +332,9 @@ Every tool returns JSON. Failures are reported as structured payloads, never as 
 * **Comment and revision indexes shift.** Deleting a comment or accepting a single revision renumbers everything after it, so run `list` again between two such calls instead of reusing the old indexes.
 * **`revision(accept|reject)` without an index also walks headers and footers.** Word's `Document.AcceptAllRevisions()` covers the body only, the same gap as with `field(update-all)`.
 * **Tracked changes are recorded only while tracking is on.** `revision(set-tracking)` does not apply retroactively — turn it on before the edits you want recorded.
+* **Bookmark names are restricted by Word.** They must start with a letter, may contain only letters, digits and underscores, and are limited to 40 characters. Spaces, hyphens, dots and non-ASCII letters are rejected before the call reaches Word, which would otherwise fail with a generic COM error.
+* **Bookmarks are the stable way to refer to a passage.** Paragraph indexes shift with every insertion, bookmarks do not. Bookmark a passage once and use `bookmark(get-text)` to re-read it later.
+* **`bookmark(add)` on a paragraph excludes the paragraph mark**, so `get-text` returns the text without a trailing newline. A bookmark over several paragraphs keeps the marks in between.
 
 ---
 
@@ -330,13 +355,13 @@ dotnet test WordMcp.sln --filter "Category!=RequiresWord"
 | `src/WordMcp.Core` | Command interfaces, command implementations and result models |
 | `src/WordMcp.Generators.Shared` | Source files shared by the generators; not a project of its own |
 | `src/WordMcp.Generators.Mcp` | Roslyn source generator that emits the MCP tool classes |
-| `src/WordMcp.McpServer` | stdio MCP server exposing the thirteen tools |
+| `src/WordMcp.McpServer` | stdio MCP server exposing the fourteen tools |
 | `tests/WordMcp.Core.Tests` | Unit tests plus integration tests against a real Word |
 | `tests/WordMcp.McpServer.Tests` | Tool-layer unit tests, no Word required |
 
 ### Generated tool layer
 
-Twelve of the thirteen tools are generated at build time. The command interfaces in
+Thirteen of the fourteen tools are generated at build time. The command interfaces in
 `src/WordMcp.Core/Commands` are the single source of truth for the wire contract:
 
 - `[ServiceCategory("section", "Section")]` names the tool class, `WordSectionTool`.

--- a/src/WordMcp.Core/Commands/Bookmark/BookmarkCommands.cs
+++ b/src/WordMcp.Core/Commands/Bookmark/BookmarkCommands.cs
@@ -1,0 +1,263 @@
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.Bookmark;
+
+/// <summary>
+/// Word COM implementation of <see cref="IBookmarkCommands"/>.
+/// </summary>
+public sealed partial class BookmarkCommands : IBookmarkCommands
+{
+    /// <inheritdoc />
+    public BookmarkListResult List(IWordBatch batch, int maxTextLength = 200)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxTextLength, 1);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic bookmarks = doc.Bookmarks;
+            int total = (int)bookmarks.Count;
+
+            var list = new List<BookmarkInfo>();
+
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                list.Add(Describe(doc, bookmarks[i], maxTextLength));
+            }
+
+            return new BookmarkListResult
+            {
+                TotalCount = total,
+                Bookmarks = list
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public BookmarkResult Add(
+        IWordBatch batch,
+        string name,
+        int paragraphIndex,
+        int? endParagraphIndex = null,
+        string? anchorText = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(paragraphIndex, 1);
+
+        ValidateName(name);
+
+        if (endParagraphIndex is int end)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(end, paragraphIndex);
+
+            if (anchorText is not null)
+            {
+                throw new ArgumentException(
+                    "anchor_text marks a phrase inside a single paragraph and cannot be combined "
+                    + "with end_paragraph_index.",
+                    nameof(anchorText));
+            }
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            int paragraphs = (int)doc.Paragraphs.Count;
+            int last = endParagraphIndex ?? paragraphIndex;
+
+            if (last > paragraphs)
+            {
+                throw new ArgumentOutOfRangeException(
+                    endParagraphIndex.HasValue ? nameof(endParagraphIndex) : nameof(paragraphIndex),
+                    $"Paragraph {last} does not exist. The document has {paragraphs} paragraph(s).");
+            }
+
+            if (BookmarkExists(doc, name))
+            {
+                throw new ArgumentException(
+                    $"Bookmark '{name}' already exists. Delete it first or pick another name.",
+                    nameof(name));
+            }
+
+            dynamic range = Anchor(doc, paragraphIndex, last, anchorText);
+            doc.Bookmarks.Add(name, range);
+
+            return new BookmarkResult
+            {
+                Bookmark = Describe(doc, doc.Bookmarks[name], 200),
+                TotalCount = (int)doc.Bookmarks.Count,
+                Message = $"Bookmark '{name}' added at paragraph {paragraphIndex}."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public BookmarkTextResult GetText(IWordBatch batch, string name)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ValidateName(name);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic bookmark = Require(doc, name);
+
+            string text = WordConversions.CleanRangeText((string?)bookmark.Range.Text);
+
+            return new BookmarkTextResult
+            {
+                Name = (string?)bookmark.Name ?? name,
+                Text = text,
+                Length = text.Length
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public BookmarkResult Delete(IWordBatch batch, string name)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ValidateName(name);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic bookmark = Require(doc, name);
+
+            var info = Describe(doc, bookmark, 200);
+            bookmark.Delete();
+
+            return new BookmarkResult
+            {
+                Bookmark = info,
+                TotalCount = (int)doc.Bookmarks.Count,
+                Message = $"Bookmark '{name}' deleted."
+            };
+        });
+    }
+
+    /// <summary>
+    /// Word only accepts bookmark names that start with a letter and consist of letters, digits and
+    /// underscores. Anything else fails inside Word with a generic "command failed" error, so the
+    /// rule is enforced here where a useful message can still be produced.
+    /// </summary>
+    private static void ValidateName(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        if (name.Length > 40)
+        {
+            throw new ArgumentException(
+                $"Bookmark name '{name}' is longer than the 40 characters Word allows.", nameof(name));
+        }
+
+        if (!NamePattern().IsMatch(name))
+        {
+            throw new ArgumentException(
+                $"Bookmark name '{name}' is invalid. Names must start with a letter and may only "
+                + "contain letters, digits and underscores - no spaces or punctuation.",
+                nameof(name));
+        }
+    }
+
+    [GeneratedRegex(@"^[A-Za-z][A-Za-z0-9_]*$")]
+    private static partial Regex NamePattern();
+
+    private static bool BookmarkExists(dynamic doc, string name)
+    {
+        try
+        {
+            return (bool)doc.Bookmarks.Exists(name);
+        }
+        catch (COMException)
+        {
+            return false;
+        }
+    }
+
+    private static dynamic Require(dynamic doc, string name)
+    {
+        if (!BookmarkExists(doc, name))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(name), $"Bookmark '{name}' does not exist in this document.");
+        }
+
+        return doc.Bookmarks[name];
+    }
+
+    /// <summary>
+    /// Resolves the range a bookmark covers: one paragraph, a paragraph range, or a phrase inside a
+    /// single paragraph.
+    /// </summary>
+    private static dynamic Anchor(dynamic doc, int paragraphIndex, int endParagraphIndex, string? anchorText)
+    {
+        dynamic first = doc.Paragraphs[paragraphIndex].Range;
+
+        if (!string.IsNullOrEmpty(anchorText))
+        {
+            string paragraphText = WordConversions.CleanRangeText((string?)first.Text);
+            int offset = paragraphText.IndexOf(anchorText, StringComparison.Ordinal);
+
+            if (offset < 0)
+            {
+                throw new ArgumentException(
+                    $"Paragraph {paragraphIndex} does not contain '{anchorText}'.", nameof(anchorText));
+            }
+
+            int anchorStart = (int)first.Start + offset;
+            return doc.Range(anchorStart, anchorStart + anchorText.Length);
+        }
+
+        // A paragraph range ends after its mark; dropping it keeps the bookmark on the text itself,
+        // which is what get-text is expected to return.
+        dynamic lastRange = doc.Paragraphs[endParagraphIndex].Range;
+        int start = (int)first.Start;
+        int end = Math.Max(start, (int)lastRange.End - 1);
+
+        return doc.Range(start, end);
+    }
+
+    private static BookmarkInfo Describe(dynamic doc, dynamic bookmark, int maxTextLength)
+    {
+        dynamic range = bookmark.Range;
+        string text = WordConversions.CleanRangeText((string?)range.Text);
+
+        return new BookmarkInfo
+        {
+            Name = (string?)bookmark.Name ?? string.Empty,
+            Start = (int)range.Start,
+            End = (int)range.End,
+            Empty = (bool)bookmark.Empty,
+            ParagraphIndex = ParagraphIndexOf(doc, (int)range.Start),
+            Text = text.Length > maxTextLength ? text[..maxTextLength] : text
+        };
+    }
+
+    private static int ParagraphIndexOf(dynamic doc, int start)
+    {
+        try
+        {
+            int count = (int)doc.Paragraphs.Count;
+
+            for (int i = 1; i <= count; i++)
+            {
+                dynamic range = doc.Paragraphs[i].Range;
+                if (start >= (int)range.Start && start < (int)range.End)
+                    return i;
+            }
+        }
+        catch (COMException)
+        {
+            // Falling back to 0 keeps the rest of the bookmark usable.
+        }
+
+        return 0;
+    }
+}

--- a/src/WordMcp.Core/Commands/Bookmark/IBookmarkCommands.cs
+++ b/src/WordMcp.Core/Commands/Bookmark/IBookmarkCommands.cs
@@ -1,0 +1,72 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Bookmark;
+
+/// <summary>
+/// Bookmark operations: listing, adding, reading and deleting named positions in a document.
+/// </summary>
+[ServiceCategory("bookmark", "Bookmark")]
+[McpTool("bookmark",
+    Title = "Bookmark Operations",
+    Description = "Bookmark operations on an open document. "
+        + "bookmark(list, session_id) returns every bookmark with its name, paragraph index and a "
+        + "preview of the bookmarked text. "
+        + "bookmark(add, session_id, name=\"Intro\", paragraph_index=2) bookmarks a paragraph; pass "
+        + "end_paragraph_index to span several paragraphs, or anchor_text to bookmark just a phrase "
+        + "inside the paragraph. "
+        + "bookmark(get-text, session_id, name=\"Intro\") returns the full bookmarked text, which is "
+        + "the reliable way to re-read a passage after edits have shifted every index. "
+        + "bookmark(delete, session_id, name=\"Intro\") removes the bookmark; the text stays. "
+        + "Bookmark names must start with a letter and may only contain letters, digits and "
+        + "underscores - Word rejects spaces and punctuation with an unhelpful error, so they are "
+        + "checked before the call reaches Word. "
+        + "Bookmarks survive edits elsewhere in the document, which makes them the stable way to "
+        + "refer to a passage across several calls.")]
+public interface IBookmarkCommands
+{
+    /// <summary>
+    /// Lists the bookmarks of the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="maxTextLength">Maximum preview length per bookmark.</param>
+    /// <returns>The bookmarks.</returns>
+    [ServiceAction("list")]
+    BookmarkListResult List(IWordBatch batch, int maxTextLength = 200);
+
+    /// <summary>
+    /// Adds a bookmark to a paragraph, a paragraph range or a phrase inside a paragraph.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="name">The bookmark name.</param>
+    /// <param name="paragraphIndex">1-based index of the first paragraph.</param>
+    /// <param name="endParagraphIndex">1-based index of the last paragraph. Single paragraph when omitted.</param>
+    /// <param name="anchorText">Bookmark only this phrase inside the paragraph. Whole paragraph when omitted.</param>
+    /// <returns>The bookmark that was added.</returns>
+    [ServiceAction("add")]
+    BookmarkResult Add(
+        IWordBatch batch,
+        string name,
+        int paragraphIndex,
+        int? endParagraphIndex = null,
+        string? anchorText = null);
+
+    /// <summary>
+    /// Reads the text of a bookmark.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="name">The bookmark name.</param>
+    /// <returns>The bookmarked text.</returns>
+    [ServiceAction("get-text")]
+    BookmarkTextResult GetText(IWordBatch batch, string name);
+
+    /// <summary>
+    /// Deletes a bookmark. The bookmarked text is kept.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="name">The bookmark name.</param>
+    /// <returns>The number of bookmarks left.</returns>
+    [ServiceAction("delete")]
+    BookmarkResult Delete(IWordBatch batch, string name);
+}

--- a/src/WordMcp.Core/Models/BookmarkResults.cs
+++ b/src/WordMcp.Core/Models/BookmarkResults.cs
@@ -1,0 +1,64 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Metadata for a single bookmark of a document.
+/// </summary>
+public sealed class BookmarkInfo
+{
+    /// <summary>Gets or sets the bookmark name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the 1-based index of the paragraph the bookmark starts in.</summary>
+    public int ParagraphIndex { get; set; }
+
+    /// <summary>Gets or sets the character offset the bookmark starts at.</summary>
+    public int Start { get; set; }
+
+    /// <summary>Gets or sets the character offset the bookmark ends at.</summary>
+    public int End { get; set; }
+
+    /// <summary>Gets or sets whether the bookmark marks a position rather than a span of text.</summary>
+    public bool Empty { get; set; }
+
+    /// <summary>Gets or sets the bookmarked text, shortened for the listing.</summary>
+    public string Text { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// The bookmarks of a document.
+/// </summary>
+public sealed class BookmarkListResult : ResultBase
+{
+    /// <summary>Gets or sets the number of bookmarks in the document.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets the bookmarks.</summary>
+    public IReadOnlyList<BookmarkInfo> Bookmarks { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation on a single bookmark.
+/// </summary>
+public sealed class BookmarkResult : ResultBase
+{
+    /// <summary>Gets or sets the bookmark the operation acted on.</summary>
+    public BookmarkInfo? Bookmark { get; set; }
+
+    /// <summary>Gets or sets the number of bookmarks left in the document.</summary>
+    public int TotalCount { get; set; }
+}
+
+/// <summary>
+/// The full text of a bookmark.
+/// </summary>
+public sealed class BookmarkTextResult : ResultBase
+{
+    /// <summary>Gets or sets the bookmark name.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the bookmarked text.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the length of the bookmarked text in characters.</summary>
+    public int Length { get; set; }
+}

--- a/src/WordMcp.McpServer/WordServices.cs
+++ b/src/WordMcp.McpServer/WordServices.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using WordMcp.ComInterop.Session;
 using WordMcp.Core.Commands.Document;
+using WordMcp.Core.Commands.Bookmark;
 using WordMcp.Core.Commands.Comment;
 using WordMcp.Core.Commands.Field;
 using WordMcp.Core.Commands.HeaderFooter;
@@ -77,6 +78,9 @@ internal static class WordServices
 
     /// <summary>Gets the revision command implementation.</summary>
     public static IRevisionCommands Revisions { get; } = new RevisionCommands();
+
+    /// <summary>Gets the bookmark command implementation.</summary>
+    public static IBookmarkCommands Bookmarks { get; } = new BookmarkCommands();
 
     /// <summary>
     /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.

--- a/tests/WordMcp.Core.Tests/BookmarkIntegrationTests.cs
+++ b/tests/WordMcp.Core.Tests/BookmarkIntegrationTests.cs
@@ -1,0 +1,159 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.Bookmark;
+using WordMcp.Core.Commands.Paragraph;
+using WordMcp.Core.Commands.Text;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Integration tests for the bookmark commands against a real Word instance.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class BookmarkIntegrationTests : IDisposable
+{
+    private static readonly BookmarkCommands Bookmarks = new();
+    private static readonly ParagraphCommands Paragraphs = new();
+    private static readonly TextCommands Texts = new();
+
+    private readonly SessionManager _sessions = new();
+    private readonly string _directory;
+    private readonly string _sessionId;
+
+    private IWordBatch Batch => _sessions.GetBatch(_sessionId);
+
+    public BookmarkIntegrationTests()
+    {
+        _directory = Directory
+            .CreateDirectory(Path.Combine(Path.GetTempPath(), "wordmcp-bookmark-" + Guid.NewGuid().ToString("N")))
+            .FullName;
+
+        _sessionId = _sessions.Create(Path.Combine(_directory, "bookmarks.docx")).SessionId;
+    }
+
+    [Fact]
+    public void Bookmark_AddListGetTextAndDeleteRoundTrip()
+    {
+        int index = Paragraphs.Add(Batch, "The introduction explains the scope.").Paragraph!.Index;
+
+        var added = Bookmarks.Add(Batch, "Intro", index);
+
+        Assert.Equal("Intro", added.Bookmark!.Name);
+        Assert.Equal(index, added.Bookmark.ParagraphIndex);
+        Assert.False(added.Bookmark.Empty);
+        Assert.Equal(1, added.TotalCount);
+
+        var list = Bookmarks.List(Batch);
+        Assert.Contains(list.Bookmarks, b => b.Name == "Intro");
+
+        var text = Bookmarks.GetText(Batch, "Intro");
+        Assert.Equal("The introduction explains the scope.", text.Text);
+        Assert.Equal(text.Text.Length, text.Length);
+
+        var deleted = Bookmarks.Delete(Batch, "Intro");
+        Assert.Equal(0, deleted.TotalCount);
+        Assert.Empty(Bookmarks.List(Batch).Bookmarks);
+    }
+
+    [Fact]
+    public void Bookmark_AnchorTextNarrowsTheBookmarkToAPhrase()
+    {
+        int index = Paragraphs.Add(Batch, "Revenue grew by fifteen percent last year.").Paragraph!.Index;
+
+        Bookmarks.Add(Batch, "Growth", index, null, "fifteen percent");
+
+        Assert.Equal("fifteen percent", Bookmarks.GetText(Batch, "Growth").Text);
+    }
+
+    [Fact]
+    public void Bookmark_SpansSeveralParagraphs()
+    {
+        int first = Paragraphs.Add(Batch, "First paragraph.").Paragraph!.Index;
+        Paragraphs.Add(Batch, "Second paragraph.");
+        int last = Paragraphs.Add(Batch, "Third paragraph.").Paragraph!.Index;
+
+        Bookmarks.Add(Batch, "Block", first, last);
+
+        string text = Bookmarks.GetText(Batch, "Block").Text;
+        Assert.Contains("First paragraph.", text, StringComparison.Ordinal);
+        Assert.Contains("Third paragraph.", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Bookmark_SurvivesAnEditInAnEarlierParagraph()
+    {
+        Paragraphs.Add(Batch, "Alpha paragraph.");
+        int index = Paragraphs.Add(Batch, "The bookmarked passage.").Paragraph!.Index;
+        Bookmarks.Add(Batch, "Passage", index);
+
+        Texts.Replace(Batch, "Alpha", "Alpha and a good deal more text");
+
+        Assert.Equal("The bookmarked passage.", Bookmarks.GetText(Batch, "Passage").Text);
+    }
+
+    [Fact]
+    public void Bookmark_AddRejectsADuplicateName()
+    {
+        int index = Paragraphs.Add(Batch, "Some paragraph.").Paragraph!.Index;
+        Bookmarks.Add(Batch, "Twice", index);
+
+        Assert.Throws<ArgumentException>(() => Bookmarks.Add(Batch, "Twice", index));
+    }
+
+    [Fact]
+    public void Bookmark_AddRejectsAMissingParagraph()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Bookmarks.Add(Batch, "Nowhere", 500));
+
+    [Fact]
+    public void Bookmark_AddRejectsAnchorTextThatIsNotInTheParagraph()
+    {
+        int index = Paragraphs.Add(Batch, "A short sentence.").Paragraph!.Index;
+
+        Assert.Throws<ArgumentException>(() => Bookmarks.Add(Batch, "Missing", index, null, "not present"));
+    }
+
+    [Fact]
+    public void Bookmark_GetTextRejectsAnUnknownName()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Bookmarks.GetText(Batch, "Unknown"));
+
+    [Fact]
+    public void Bookmark_DeleteRejectsAnUnknownName()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Bookmarks.Delete(Batch, "Unknown"));
+
+    [Fact]
+    public void Bookmark_ListShortensThePreview()
+    {
+        int index = Paragraphs.Add(Batch, new string('x', 300)).Paragraph!.Index;
+        Bookmarks.Add(Batch, "Long", index);
+
+        var info = Assert.Single(Bookmarks.List(Batch, maxTextLength: 20).Bookmarks);
+
+        Assert.Equal(20, info.Text.Length);
+        Assert.Equal(300, Bookmarks.GetText(Batch, "Long").Length);
+    }
+
+    [Fact]
+    public void Bookmark_DeleteKeepsTheText()
+    {
+        int index = Paragraphs.Add(Batch, "Text that must stay.").Paragraph!.Index;
+        Bookmarks.Add(Batch, "Keeper", index);
+
+        Bookmarks.Delete(Batch, "Keeper");
+
+        Assert.Contains("Text that must stay.", Texts.Get(Batch).Text, StringComparison.Ordinal);
+    }
+
+    public void Dispose()
+    {
+        _sessions.Dispose();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A locked temp file must not fail the test run.
+        }
+    }
+}

--- a/tests/WordMcp.Core.Tests/BookmarkValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/BookmarkValidationTests.cs
@@ -1,0 +1,76 @@
+using WordMcp.Core.Commands.Bookmark;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Argument validation of the bookmark commands. Everything asserted here happens before the batch
+/// is touched, so these tests need no Word installation and run in CI.
+/// </summary>
+public class BookmarkValidationTests
+{
+    private static readonly BookmarkCommands Bookmarks = new();
+    private static readonly ThrowingBatch Batch = new();
+
+    [Theory]
+    [InlineData("My Bookmark")]
+    [InlineData("1Intro")]
+    [InlineData("intro-section")]
+    [InlineData("intro.section")]
+    [InlineData("_intro")]
+    [InlineData("Überschrift")]
+    public void Add_RejectsNamesWordWouldReject(string name)
+        => Assert.Throws<ArgumentException>(() => Bookmarks.Add(Batch, name, 1));
+
+    [Theory]
+    [InlineData("Intro")]
+    [InlineData("section_2")]
+    [InlineData("a")]
+    public void Add_AcceptsValidNames(string name)
+        => Assert.Throws<NotSupportedException>(() => Bookmarks.Add(Batch, name, 1));
+
+    [Fact]
+    public void Add_RejectsNamesLongerThanFortyCharacters()
+        => Assert.Throws<ArgumentException>(() => Bookmarks.Add(Batch, new string('a', 41), 1));
+
+    [Fact]
+    public void Add_AcceptsANameOfExactlyFortyCharacters()
+        => Assert.Throws<NotSupportedException>(() => Bookmarks.Add(Batch, new string('a', 40), 1));
+
+    [Fact]
+    public void Add_RejectsParagraphIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Bookmarks.Add(Batch, "Intro", 0));
+
+    [Fact]
+    public void Add_RejectsEndBeforeStart()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Bookmarks.Add(Batch, "Intro", 4, 2));
+
+    [Fact]
+    public void Add_RejectsAnchorTextCombinedWithAParagraphRange()
+        => Assert.Throws<ArgumentException>(() => Bookmarks.Add(Batch, "Intro", 1, 3, "phrase"));
+
+    [Fact]
+    public void Add_AcceptsAnchorTextForASingleParagraph()
+        => Assert.Throws<NotSupportedException>(() => Bookmarks.Add(Batch, "Intro", 1, null, "phrase"));
+
+    [Fact]
+    public void List_RejectsMaxTextLengthBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Bookmarks.List(Batch, 0));
+
+    [Fact]
+    public void GetText_RejectsInvalidNames()
+        => Assert.Throws<ArgumentException>(() => Bookmarks.GetText(Batch, "no good"));
+
+    [Fact]
+    public void Delete_RejectsEmptyNames()
+        => Assert.Throws<ArgumentException>(() => Bookmarks.Delete(Batch, "   "));
+
+    [Fact]
+    public void AllCommandsRejectNullBatch()
+    {
+        Assert.Throws<ArgumentNullException>(() => Bookmarks.List(null!));
+        Assert.Throws<ArgumentNullException>(() => Bookmarks.Add(null!, "Intro", 1));
+        Assert.Throws<ArgumentNullException>(() => Bookmarks.GetText(null!, "Intro"));
+        Assert.Throws<ArgumentNullException>(() => Bookmarks.Delete(null!, "Intro"));
+    }
+}


### PR DESCRIPTION
Adds the `bookmark` tool from #24.

| Action | Purpose |
|---|---|
| `list` | Bookmarks with name, paragraph index and a preview of the marked text |
| `add` | Bookmark a paragraph, a paragraph range, or a phrase inside a paragraph |
| `get-text` | Read the full bookmarked text |
| `delete` | Remove a bookmark; the text stays |

### Why it matters

Paragraph indexes shift with every insertion. A bookmark does not, so it is the reliable way for an assistant to refer back to a passage across several calls - bookmark it once, then re-read it with `get-text`.

### Notes

- Word rejects bookmark names with spaces or punctuation with a generic COM error. The rule (start with a letter, then letters/digits/underscores, max 40 characters) is enforced before the call reaches Word so the message is actually useful.
- A paragraph bookmark deliberately drops the paragraph mark, so `get-text` returns the text without a trailing newline. A bookmark spanning several paragraphs keeps the marks in between.
- `add` rejects a duplicate name rather than silently moving the existing bookmark, which is what Word would do.

### Not included: `screenshot`

The second half of #24 needs a PDF rasterizer to turn `ExportAsFixedFormat` output into a PNG. That is a new dependency and deserves its own decision, so #24 stays open for it.

### Verification

- Release build: 0 warnings, 0 errors
- 11 new Word integration tests and 15 validation tests, all green on the first run

Refs #24
