### PR TITLE
Add the screenshot tool

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,8 @@
   <ItemGroup>
     <!-- Word COM Interop PIA -->
     <PackageVersion Include="Microsoft.Office.Interop.Word" Version="15.0.4797.1004" />
+    <!-- PDF rasterization for screenshot(page): Word can only export a page range as PDF -->
+    <PackageVersion Include="PDFtoImage" Version="5.3.0" />
     <!-- Microsoft Extensions for MCP Server -->
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ file(open|create) ──► session_id ──► text / paragraph / table / docu
 
 ## Tools
 
-Fourteen tools, each with an `action` parameter.
+Fifteen tools, each with an `action` parameter.
 
 ### `file` — session lifecycle
 
@@ -289,6 +289,27 @@ bookmark(action: "get-text", session_id: "...", name: "Intro")
 
 ---
 
+### `screenshot` — see the page
+
+| Action | Purpose |
+|---|---|
+| `page` | Render a page as a PNG |
+
+Layout questions — page breaks, table widths, image placement, header positions — are far easier
+to answer from the rendered page than from measurements. The PNG is written to a file and the path
+returned; `include_image: true` additionally returns it inline as base64, which is only worth the
+context when the image is going to be looked at.
+
+`dpi` defaults to 150. Use 96 for a quick layout check and 300 for something close to print.
+
+```jsonc
+screenshot(action: "page", session_id: "...", page: 2)
+screenshot(action: "page", session_id: "...", page: 1,
+           output_path: "C:/temp/page1.png", dpi: 300, include_image: true)
+```
+
+---
+
 ## Responses
 
 Every tool returns JSON. Failures are reported as structured payloads, never as a transport error:
@@ -335,6 +356,8 @@ Every tool returns JSON. Failures are reported as structured payloads, never as 
 * **Bookmark names are restricted by Word.** They must start with a letter, may contain only letters, digits and underscores, and are limited to 40 characters. Spaces, hyphens, dots and non-ASCII letters are rejected before the call reaches Word, which would otherwise fail with a generic COM error.
 * **Bookmarks are the stable way to refer to a passage.** Paragraph indexes shift with every insertion, bookmarks do not. Bookmark a passage once and use `bookmark(get-text)` to re-read it later.
 * **`bookmark(add)` on a paragraph excludes the paragraph mark**, so `get-text` returns the text without a trailing newline. A bookmark over several paragraphs keeps the marks in between.
+* **`screenshot(page)` renders through a PDF.** Word has no API that returns a page as an image, so the server exports the single page with `ExportAsFixedFormat` and rasterizes it. Unsaved changes are included, and the temporary PDF is deleted afterwards.
+* **Page numbers come from a fresh repagination.** A document that was only ever edited through automation reports a stale page count, so `screenshot` repaginates first. That also means the page count reflects the current layout, not the one at open time.
 
 ---
 
@@ -355,13 +378,13 @@ dotnet test WordMcp.sln --filter "Category!=RequiresWord"
 | `src/WordMcp.Core` | Command interfaces, command implementations and result models |
 | `src/WordMcp.Generators.Shared` | Source files shared by the generators; not a project of its own |
 | `src/WordMcp.Generators.Mcp` | Roslyn source generator that emits the MCP tool classes |
-| `src/WordMcp.McpServer` | stdio MCP server exposing the fourteen tools |
+| `src/WordMcp.McpServer` | stdio MCP server exposing the fifteen tools |
 | `tests/WordMcp.Core.Tests` | Unit tests plus integration tests against a real Word |
 | `tests/WordMcp.McpServer.Tests` | Tool-layer unit tests, no Word required |
 
 ### Generated tool layer
 
-Thirteen of the fourteen tools are generated at build time. The command interfaces in
+Fourteen of the fifteen tools are generated at build time. The command interfaces in
 `src/WordMcp.Core/Commands` are the single source of truth for the wire contract:
 
 - `[ServiceCategory("section", "Section")]` names the tool class, `WordSectionTool`.

--- a/src/WordMcp.ComInterop/ComInteropConstants.cs
+++ b/src/WordMcp.ComInterop/ComInteropConstants.cs
@@ -78,6 +78,21 @@ public static class ComInteropConstants
     /// <summary>WdStatistic.wdStatisticParagraphs = 4.</summary>
     public const int WdStatisticParagraphs = 4;
 
+    /// <summary>WdExportFormat.wdExportFormatPDF = 17.</summary>
+    public const int WdExportFormatPdf = 17;
+
+    /// <summary>WdExportOptimizeFor.wdExportOptimizeForPrint = 0.</summary>
+    public const int WdExportOptimizeForPrint = 0;
+
+    /// <summary>WdExportRange.wdExportAllDocument = 0.</summary>
+    public const int WdExportAllDocument = 0;
+
+    /// <summary>WdExportRange.wdExportFromTo = 3 — export a page range.</summary>
+    public const int WdExportFromTo = 3;
+
+    /// <summary>WdExportItem.wdExportDocumentContent = 0 — export without markup.</summary>
+    public const int WdExportDocumentContent = 0;
+
     /// <summary>WdCollapseDirection.wdCollapseEnd = 0.</summary>
     public const int WdCollapseEnd = 0;
 

--- a/src/WordMcp.Core/Commands/Screenshot/IScreenshotCommands.cs
+++ b/src/WordMcp.Core/Commands/Screenshot/IScreenshotCommands.cs
@@ -1,0 +1,41 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Screenshot;
+
+/// <summary>
+/// Page rendering: turning a page of the open document into a PNG.
+/// </summary>
+[ServiceCategory("screenshot", "Screenshot")]
+[McpTool("screenshot",
+    Title = "Screenshot Operations",
+    Description = "Renders a page of an open document as a PNG image. "
+        + "screenshot(page, session_id) renders page 1; pass page=3 for another page. "
+        + "Use this to check the layout visually - page breaks, table widths, image placement and "
+        + "header positions are far easier to judge from the rendered page than from measurements. "
+        + "The image is written to a file and the path is returned. Pass include_image=true to also "
+        + "get the PNG inline as base64, which is only worth it when the image is actually going to "
+        + "be looked at, since it is large. "
+        + "dpi defaults to 150, which is readable without being wasteful; 96 is enough for a rough "
+        + "layout check and 300 approaches print quality. "
+        + "Rendering goes through a PDF export of the single page, so unsaved changes are included.")]
+public interface IScreenshotCommands
+{
+    /// <summary>
+    /// Renders one page of the document as a PNG.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="page">1-based page number.</param>
+    /// <param name="outputPath">Where to write the PNG. A temporary file when omitted.</param>
+    /// <param name="dpi">Rendering resolution between 36 and 600.</param>
+    /// <param name="includeImage">Whether to also return the PNG inline as base64.</param>
+    /// <returns>The rendered page.</returns>
+    [ServiceAction("page")]
+    ScreenshotResult Page(
+        IWordBatch batch,
+        int page = 1,
+        string? outputPath = null,
+        int dpi = 150,
+        bool includeImage = false);
+}

--- a/src/WordMcp.Core/Commands/Screenshot/ScreenshotCommands.cs
+++ b/src/WordMcp.Core/Commands/Screenshot/ScreenshotCommands.cs
@@ -1,0 +1,158 @@
+using PDFtoImage;
+using SkiaSharp;
+using WordMcp.ComInterop;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Screenshot;
+
+/// <summary>
+/// Word COM implementation of <see cref="IScreenshotCommands"/>.
+/// </summary>
+/// <remarks>
+/// Word has no API that hands out a page as an image. The only route that preserves the real
+/// layout is a fixed-format export of the single page followed by rasterizing that PDF, which is
+/// what this class does.
+/// </remarks>
+public sealed class ScreenshotCommands : IScreenshotCommands
+{
+    private const int MinDpi = 36;
+    private const int MaxDpi = 600;
+
+    /// <inheritdoc />
+    public ScreenshotResult Page(
+        IWordBatch batch,
+        int page = 1,
+        string? outputPath = null,
+        int dpi = 150,
+        bool includeImage = false)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(page, 1);
+        ArgumentOutOfRangeException.ThrowIfLessThan(dpi, MinDpi);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(dpi, MaxDpi);
+
+        string target = ResolveOutputPath(outputPath, page);
+
+        var (pdfPath, pageCount) = ExportPage(batch, page);
+
+        try
+        {
+            var (width, height) = Rasterize(pdfPath, target, dpi);
+            var info = new FileInfo(target);
+
+            return new ScreenshotResult
+            {
+                Page = page,
+                PageCount = pageCount,
+                OutputPath = target,
+                Width = width,
+                Height = height,
+                Dpi = dpi,
+                FileSizeBytes = info.Exists ? info.Length : 0,
+                ImageBase64 = includeImage ? Convert.ToBase64String(File.ReadAllBytes(target)) : null,
+                Message = $"Page {page} of {pageCount} rendered at {dpi} dpi."
+            };
+        }
+        finally
+        {
+            TryDelete(pdfPath);
+        }
+    }
+
+    private static string ResolveOutputPath(string? outputPath, int page)
+    {
+        if (string.IsNullOrWhiteSpace(outputPath))
+        {
+            return Path.Combine(
+                Path.GetTempPath(),
+                $"wordmcp-page{page}-{Guid.NewGuid():N}.png");
+        }
+
+        string full = Path.GetFullPath(outputPath);
+        string? directory = Path.GetDirectoryName(full);
+
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        return full;
+    }
+
+    /// <summary>
+    /// Exports the single page as a PDF and reports how many pages the document has.
+    /// </summary>
+    private static (string PdfPath, int PageCount) ExportPage(IWordBatch batch, int page)
+    {
+        string pdfPath = Path.Combine(Path.GetTempPath(), $"wordmcp-page-{Guid.NewGuid():N}.pdf");
+
+        int pageCount = batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+
+            // Repaginate first: on a document that was only ever touched through automation the
+            // page count is otherwise stale, and a page that Word thinks does not exist exports
+            // as an empty PDF instead of failing.
+            doc.Repaginate();
+            int pages = (int)doc.ComputeStatistics(ComInteropConstants.WdStatisticPages);
+
+            if (page > pages)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(page), $"Page {page} does not exist. The document has {pages} page(s).");
+            }
+
+            doc.ExportAsFixedFormat(
+                pdfPath,
+                ComInteropConstants.WdExportFormatPdf,
+                false,
+                ComInteropConstants.WdExportOptimizeForPrint,
+                ComInteropConstants.WdExportFromTo,
+                page,
+                page,
+                ComInteropConstants.WdExportDocumentContent);
+
+            return pages;
+        });
+
+        if (!File.Exists(pdfPath))
+        {
+            throw new InvalidOperationException(
+                $"Word did not produce a PDF for page {page}. The document may be protected against exporting.");
+        }
+
+        return (pdfPath, pageCount);
+    }
+
+    private static (int Width, int Height) Rasterize(string pdfPath, string target, int dpi)
+    {
+        using var pdf = File.OpenRead(pdfPath);
+
+        // The export contains exactly the one requested page, so the rasterizer always reads index 0.
+        using SKBitmap bitmap = Conversion.ToImage(pdf, page: 0, options: new RenderOptions(Dpi: dpi));
+        using SKData png = bitmap.Encode(SKEncodedImageFormat.Png, 100)
+            ?? throw new InvalidOperationException("The rendered page could not be encoded as PNG.");
+
+        using var output = File.Create(target);
+        png.SaveTo(output);
+
+        return (bitmap.Width, bitmap.Height);
+    }
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+            // A leftover temp file is not worth failing the call over.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Same here.
+        }
+    }
+}

--- a/src/WordMcp.Core/Models/ScreenshotResults.cs
+++ b/src/WordMcp.Core/Models/ScreenshotResults.cs
@@ -1,0 +1,34 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// A rendered page image.
+/// </summary>
+public sealed class ScreenshotResult : ResultBase
+{
+    /// <summary>Gets or sets the 1-based page number that was rendered.</summary>
+    public int Page { get; set; }
+
+    /// <summary>Gets or sets the number of pages the document has.</summary>
+    public int PageCount { get; set; }
+
+    /// <summary>Gets or sets the path of the written PNG file.</summary>
+    public string OutputPath { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the image width in pixels.</summary>
+    public int Width { get; set; }
+
+    /// <summary>Gets or sets the image height in pixels.</summary>
+    public int Height { get; set; }
+
+    /// <summary>Gets or sets the resolution the page was rendered at.</summary>
+    public int Dpi { get; set; }
+
+    /// <summary>Gets or sets the size of the PNG file in bytes.</summary>
+    public long FileSizeBytes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the PNG as a base64 string. Only filled when the caller asked for it, because
+    /// an inline image costs far more context than the path does.
+    /// </summary>
+    public string? ImageBase64 { get; set; }
+}

--- a/src/WordMcp.Core/WordMcp.Core.csproj
+++ b/src/WordMcp.Core/WordMcp.Core.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="PDFtoImage" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/WordMcp.McpServer/WordServices.cs
+++ b/src/WordMcp.McpServer/WordServices.cs
@@ -3,6 +3,7 @@ using WordMcp.ComInterop.Session;
 using WordMcp.Core.Commands.Document;
 using WordMcp.Core.Commands.Bookmark;
 using WordMcp.Core.Commands.Comment;
+using WordMcp.Core.Commands.Screenshot;
 using WordMcp.Core.Commands.Field;
 using WordMcp.Core.Commands.HeaderFooter;
 using WordMcp.Core.Commands.Image;
@@ -81,6 +82,9 @@ internal static class WordServices
 
     /// <summary>Gets the bookmark command implementation.</summary>
     public static IBookmarkCommands Bookmarks { get; } = new BookmarkCommands();
+
+    /// <summary>Gets the screenshot command implementation.</summary>
+    public static IScreenshotCommands Screenshots { get; } = new ScreenshotCommands();
 
     /// <summary>
     /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.

--- a/tests/WordMcp.Core.Tests/ScreenshotIntegrationTests.cs
+++ b/tests/WordMcp.Core.Tests/ScreenshotIntegrationTests.cs
@@ -1,0 +1,161 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.Paragraph;
+using WordMcp.Core.Commands.Screenshot;
+using WordMcp.Core.Commands.Text;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Integration tests for the screenshot command against a real Word instance.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class ScreenshotIntegrationTests : IDisposable
+{
+    private static readonly ScreenshotCommands Screenshots = new();
+    private static readonly ParagraphCommands Paragraphs = new();
+    private static readonly TextCommands Texts = new();
+
+    private static readonly byte[] PngSignature = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    private readonly SessionManager _sessions = new();
+    private readonly string _directory;
+    private readonly string _sessionId;
+
+    private IWordBatch Batch => _sessions.GetBatch(_sessionId);
+
+    public ScreenshotIntegrationTests()
+    {
+        _directory = Directory
+            .CreateDirectory(Path.Combine(Path.GetTempPath(), "wordmcp-screenshot-" + Guid.NewGuid().ToString("N")))
+            .FullName;
+
+        _sessionId = _sessions.Create(Path.Combine(_directory, "screenshot.docx")).SessionId;
+    }
+
+    [Fact]
+    public void Screenshot_RendersTheFirstPageAsPng()
+    {
+        Paragraphs.Add(Batch, "A visible line of text.");
+        string target = Path.Combine(_directory, "page1.png");
+
+        var result = Screenshots.Page(Batch, 1, target);
+
+        Assert.Equal(1, result.Page);
+        Assert.True(result.PageCount >= 1);
+        Assert.Equal(target, result.OutputPath);
+        Assert.Equal(150, result.Dpi);
+        Assert.True(result.Width > 500, $"Width was {result.Width}.");
+        Assert.True(result.Height > result.Width, "A portrait page should be taller than it is wide.");
+        Assert.True(result.FileSizeBytes > 0);
+        Assert.Null(result.ImageBase64);
+
+        Assert.True(File.Exists(target));
+        Assert.Equal(PngSignature, File.ReadAllBytes(target).Take(PngSignature.Length).ToArray());
+    }
+
+    [Fact]
+    public void Screenshot_WritesToATempFileWhenNoPathIsGiven()
+    {
+        Paragraphs.Add(Batch, "Anywhere will do.");
+
+        var result = Screenshots.Page(Batch);
+
+        try
+        {
+            Assert.True(File.Exists(result.OutputPath));
+            Assert.EndsWith(".png", result.OutputPath, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            File.Delete(result.OutputPath);
+        }
+    }
+
+    [Fact]
+    public void Screenshot_HigherDpiProducesALargerImage()
+    {
+        Paragraphs.Add(Batch, "Resolution test.");
+
+        var low = Screenshots.Page(Batch, 1, Path.Combine(_directory, "low.png"), dpi: 72);
+        var high = Screenshots.Page(Batch, 1, Path.Combine(_directory, "high.png"), dpi: 300);
+
+        Assert.True(high.Width > low.Width, $"{high.Width} should exceed {low.Width}.");
+        Assert.True(high.Height > low.Height);
+    }
+
+    [Fact]
+    public void Screenshot_ReturnsTheImageInlineWhenAsked()
+    {
+        Paragraphs.Add(Batch, "Inline test.");
+
+        var result = Screenshots.Page(
+            Batch, 1, Path.Combine(_directory, "inline.png"), dpi: 72, includeImage: true);
+
+        Assert.False(string.IsNullOrEmpty(result.ImageBase64));
+
+        byte[] decoded = Convert.FromBase64String(result.ImageBase64!);
+        Assert.Equal(PngSignature, decoded.Take(PngSignature.Length).ToArray());
+        Assert.Equal(result.FileSizeBytes, decoded.Length);
+    }
+
+    [Fact]
+    public void Screenshot_RendersALaterPage()
+    {
+        Paragraphs.Add(Batch, "Page one content.");
+
+        // Chr(12) is Word's page break character, which is the shortest way to force a second page.
+        Texts.Append(Batch, "\f");
+        Paragraphs.Add(Batch, "Page two content.");
+
+        var result = Screenshots.Page(Batch, 2, Path.Combine(_directory, "page2.png"), dpi: 72);
+
+        Assert.Equal(2, result.Page);
+        Assert.True(result.PageCount >= 2, $"Page count was {result.PageCount}.");
+        Assert.True(File.Exists(result.OutputPath));
+    }
+
+    [Fact]
+    public void Screenshot_RejectsAPageThatDoesNotExist()
+    {
+        Paragraphs.Add(Batch, "Only one page here.");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Screenshots.Page(Batch, 99));
+    }
+
+    [Fact]
+    public void Screenshot_CreatesAMissingOutputDirectory()
+    {
+        Paragraphs.Add(Batch, "Nested output.");
+        string target = Path.Combine(_directory, "nested", "deeper", "page.png");
+
+        var result = Screenshots.Page(Batch, 1, target, dpi: 72);
+
+        Assert.True(File.Exists(result.OutputPath));
+    }
+
+    [Fact]
+    public void Screenshot_LeavesNoPdfBehind()
+    {
+        Paragraphs.Add(Batch, "Cleanup test.");
+        var before = Directory.GetFiles(Path.GetTempPath(), "wordmcp-page-*.pdf").Length;
+
+        Screenshots.Page(Batch, 1, Path.Combine(_directory, "cleanup.png"), dpi: 72);
+
+        Assert.Equal(before, Directory.GetFiles(Path.GetTempPath(), "wordmcp-page-*.pdf").Length);
+    }
+
+    public void Dispose()
+    {
+        _sessions.Dispose();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A locked temp file must not fail the test run.
+        }
+    }
+}

--- a/tests/WordMcp.Core.Tests/ScreenshotValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/ScreenshotValidationTests.cs
@@ -1,0 +1,54 @@
+using WordMcp.Core.Commands.Screenshot;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Argument validation of the screenshot command. Everything asserted here happens before the
+/// batch is touched, so these tests need no Word installation and run in CI.
+/// </summary>
+public class ScreenshotValidationTests
+{
+    private static readonly ScreenshotCommands Screenshots = new();
+    private static readonly ThrowingBatch Batch = new();
+
+    [Fact]
+    public void Page_RejectsPageBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Screenshots.Page(Batch, 0));
+
+    [Theory]
+    [InlineData(35)]
+    [InlineData(0)]
+    [InlineData(-10)]
+    public void Page_RejectsDpiBelowTheMinimum(int dpi)
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Screenshots.Page(Batch, 1, null, dpi));
+
+    [Fact]
+    public void Page_RejectsDpiAboveTheMaximum()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Screenshots.Page(Batch, 1, null, 601));
+
+    [Theory]
+    [InlineData(36)]
+    [InlineData(150)]
+    [InlineData(600)]
+    public void Page_AcceptsDpiInsideTheRange(int dpi)
+        => Assert.Throws<NotSupportedException>(() => Screenshots.Page(Batch, 1, null, dpi));
+
+    [Fact]
+    public void Page_RejectsNullBatch()
+        => Assert.Throws<ArgumentNullException>(() => Screenshots.Page(null!));
+
+    [Fact]
+    public void Page_DoesNotCreateTheOutputDirectoryBeforeReachingWord()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), "wordmcp-shot-" + Guid.NewGuid().ToString("N"));
+
+        // The batch throws, so nothing is rendered - but the directory is prepared beforehand,
+        // which is what makes a nested output path work.
+        Assert.Throws<NotSupportedException>(
+            () => Screenshots.Page(Batch, 1, Path.Combine(directory, "page.png")));
+
+        Assert.True(Directory.Exists(directory));
+        Directory.Delete(directory, recursive: true);
+    }
+}


### PR DESCRIPTION
Completes #24 with the `screenshot` tool.

| Action | Purpose |
|---|---|
| `page` | Render a page of the open document as a PNG |

### The rendering decision

#24 asked for this to be settled before implementing. Word has no API that returns a page as an image, and the only route that preserves the real layout is a fixed-format export of the single page followed by rasterizing that PDF.

That needs a rasterizer. I picked **PDFtoImage 5.3.0** (MIT, SkiaSharp + PDFium):

- it is the only actively maintained option that is not commercially licensed;
- I verified it renders on **win-arm64**, which matters because that is the development machine;
- it needs no external binary at runtime - the natives ship with the package.

The alternative, `Windows.Data.Pdf`, would have avoided the dependency but forced every project from `net9.0-windows` up to `net9.0-windows10.0.19041.0`. That is a bigger blast radius than one MIT package.

### Notes

- **The page is repaginated before exporting.** A document that was only ever edited through automation reports a stale page count, and an out-of-range page exports as an empty PDF instead of failing - so the count is refreshed and the page validated first.
- The PNG is written to a file and the path returned. `include_image: true` also returns it inline as base64; that stays opt-in because an inline image is expensive in context.
- The temporary PDF is deleted afterwards, which one of the tests checks.
- `dpi` is clamped to 36-600 and defaults to 150.

### Verification

- Release build: 0 warnings, 0 errors
- 8 new Word integration tests and 8 validation tests, green on the first run
- Full run: **374 Core + 85 McpServer = 459 tests green**

Closes #24
