### PR TITLE
Add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug report
+description: Something does not work the way it should
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most problems in this project come down to one of three things: the Word version, an open
+        dialog blocking automation, or a document that is not what it looks like. The questions
+        below exist to rule those out quickly.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you expect, and what did you get instead?
+      placeholder: |
+        Called table(read) on a document with merged cells and got empty strings for the
+        merged ones. I expected the text of the merged cell.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: >
+        The tool calls in order, with their arguments. If a specific document is needed, describe
+        what is in it - or attach it, with anything confidential removed.
+      placeholder: |
+        1. file(action: "open", path: "C:/temp/report.docx")
+        2. table(action: "read", session_id: "...", table_index: 1)
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Error output
+      description: The full JSON error response, or the server log if there is no response.
+      render: json
+
+  - type: input
+    id: word-version
+    attributes:
+      label: Word version
+      description: In Word, File > Account > About Word. The build number matters.
+      placeholder: "Microsoft 365, 16.0.20412, German UI"
+    validations:
+      required: true
+
+  - type: input
+    id: server-version
+    attributes:
+      label: Server version
+      description: The version of the MCP server, or the commit if you built it yourself.
+      placeholder: "0.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Windows version and architecture
+      placeholder: "Windows 11 24H2, ARM64"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before filing
+      options:
+        - label: No Word dialog was open on the desktop when this happened
+        - label: The document was not open in Word in another window
+        - label: The document is not rights-protected (IRM/AIP)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/trsdn/mcp-server-word/security/advisories/new
+    about: Report privately through a security advisory, not as a public issue.
+  - name: Question about using the server
+    url: https://github.com/trsdn/mcp-server-word/discussions
+    about: Setup, client configuration and "how do I do X" belong in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: A tool or action the server should support
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The server is organized as tools with actions - `table(read)`, `style(modify)` and so on.
+        A request is easiest to act on when it names where it belongs.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What you are trying to do
+      description: >
+        Describe the document work, not the API you have in mind. What the assistant is supposed to
+        accomplish usually suggests a better shape than a guessed method signature.
+      placeholder: |
+        I want an assistant to fill a contract template: find the placeholder fields, replace them
+        with values, and confirm nothing was left unfilled.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed tool and actions
+      description: Which tool would this belong to, and what would the call look like?
+      placeholder: |
+        content-control(list) and content-control(set) - new tool, since placeholders in real
+        templates are content controls rather than plain text.
+      render: text
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you tried instead
+      description: Which existing tools you used, and where they fell short.
+
+  - type: dropdown
+    id: word-support
+    attributes:
+      label: Does Word expose this?
+      description: >
+        Not a requirement - but if you already know the COM API involved, it saves a research pass.
+      options:
+        - "Yes, I know the Word API for it"
+        - "Probably, but I have not checked"
+        - "No idea"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,39 @@
+<!--
+  Keep this short. The diff says what changed; this says why, and what you did to convince
+  yourself it works.
+-->
+
+## What this changes
+
+<!-- One or two sentences. -->
+
+## Why
+
+<!-- The problem being solved. Link the issue: "Closes #12" or "Refs #12". -->
+
+## How it was verified
+
+<!--
+  Word automation fails in ways a compiler cannot catch, so say what you actually ran.
+
+  - Word integration tests are excluded in CI. If you touched a command implementation, run them
+    locally: dotnet test --filter "FullyQualifiedName~YourIntegrationTests"
+  - Note the Word version and UI language you tested against - localization breaks style and
+    caption handling in particular.
+-->
+
+- [ ] `dotnet build -c Release` is clean (warnings are errors in this repo)
+- [ ] `dotnet test --filter "Category!=RequiresWord"` passes
+- [ ] Word integration tests pass locally, or this change cannot affect them
+
+Word version tested against:
+
+## Checklist
+
+- [ ] A new tool has an interface, a COM implementation and a `WordServices` property — the MCP
+      tool class itself is generated, so it is not written by hand
+- [ ] New behaviour has tests, including the failure paths
+- [ ] Argument validation happens before `batch.Execute`, so it is testable without Word
+- [ ] README updated if a tool, action or pitfall changed
+- [ ] Anything surprising about Word's behaviour is written down as a comment at the point where it
+      bites, not only in this description

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+## The short version
+
+Be decent to people. Assume the person on the other end is acting in good faith and has less
+context than you do.
+
+## What is expected
+
+* Discuss the code, not the person who wrote it. "This leaks a COM object" is feedback; "you clearly
+  don't understand COM" is not.
+* Accept that a maintainer may decline a change. A project has a shape, and not every good idea
+  fits it.
+* Be patient. This is a spare-time project; a reply can take a while.
+* When you disagree, say what you would do instead and why.
+
+## What is not acceptable
+
+* Harassment, insults or personal attacks, in issues, pull requests or any other project space.
+* Discriminatory or demeaning remarks — about anyone, for any reason.
+* Publishing someone's private information without their permission.
+* Persistent off-topic disruption after being asked to stop.
+
+## Scope
+
+This applies to everything in this repository — issues, pull requests, discussions, commit
+messages and code review — and to anywhere someone is representing the project.
+
+## Enforcement
+
+Report a problem to the maintainer at
+[github.com/trsdn](https://github.com/trsdn), or through
+[GitHub's abuse reporting](https://github.com/contact/report-abuse) if the maintainer is the
+problem.
+
+Reports are handled privately. Depending on what happened, the response ranges from a private
+request to stop, through editing or removing the offending content, to blocking the account from
+the repository. Nobody is owed an explanation of a report they were the subject of beyond what
+action was taken and why.
+
+## Attribution
+
+This document is inspired by the [Contributor Covenant](https://www.contributor-covenant.org) but
+is deliberately shorter and written for a single-maintainer project.

--- a/README.md
+++ b/README.md
@@ -411,6 +411,16 @@ Tests that need a real Word installation are marked `[Trait("Category", "Require
 | Operation times out | A Word dialog is waiting for input; close it and retry |
 | `The file is already open in Word` | Close the document in the Word UI |
 
+## Contributing
+
+Bug reports and feature requests go through the [issue templates](https://github.com/trsdn/mcp-server-word/issues/new/choose).
+Pull requests are welcome; the checklist in the PR template covers what the build enforces.
+
+Please read the [Code of Conduct](CODE_OF_CONDUCT.md) first.
+
+**Do not file a public issue for a security problem** — report it privately as described in the
+[security policy](SECURITY.md).
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,57 @@
+# Security Policy
+
+## Supported versions
+
+This project is pre-1.0. Only the latest release receives security fixes.
+
+| Version | Supported |
+|---|---|
+| 0.1.x | ✅ |
+| < 0.1 | ❌ |
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security problem.**
+
+Report it privately through GitHub:
+[**Report a vulnerability**](https://github.com/trsdn/mcp-server-word/security/advisories/new).
+
+Please include what you have — the affected version, what an attacker can achieve, and the steps
+to reproduce it. A working proof of concept helps but is not required to file a report.
+
+Expect an acknowledgement within seven days. This is a spare-time project, so a fix may take
+longer than that; you will be kept informed either way, and credited in the advisory unless you
+ask otherwise.
+
+## Threat model
+
+The server automates a local Microsoft Word installation on behalf of an MCP client. That shapes
+what counts as a vulnerability here.
+
+**In scope**
+
+* A tool argument that escapes the intended document — writing to, reading from or deleting a path
+  the caller did not name.
+* Argument handling that reaches Word in a way the caller did not ask for, for example a path or
+  field code that Word interprets rather than treats as data.
+* A crafted document that makes the server execute code while it is being processed.
+* Credentials or document content leaking into logs or error messages.
+
+**Out of scope**
+
+* An MCP client that sends destructive commands. The server executes what it is asked to; deciding
+  what to ask is the client's job, which is why destructive actions are marked as such in the tool
+  metadata.
+* Macros in a `.docm` a user deliberately opens. The server does not run macros itself, but Word's
+  own macro settings govern what happens on open.
+* Anything requiring an attacker who already has interactive access to the machine, which is the
+  same trust level the server itself runs at.
+* Vulnerabilities in Microsoft Word — report those to
+  [Microsoft MSRC](https://msrc.microsoft.com/report).
+
+## Operating notes
+
+* The server runs with the privileges of the user who starts it and can read and write any file
+  that user can. Treat access to it as equivalent to shell access.
+* Rights-protected documents (IRM/AIP) are rejected before Word is launched.
+* Documents are automated through COM, so a Word instance is running for the lifetime of a session.


### PR DESCRIPTION
Covers the community-files and security-settings part of #29.

### Files added

| File | Notes |
|---|---|
| `SECURITY.md` | Private reporting via security advisory, plus an explicit threat model |
| `CODE_OF_CONDUCT.md` | Short, written for a single-maintainer project |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Asks for the Word build, UI language and open dialogs up front |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Framed around tools and actions, since that is how the server is organized |
| `.github/ISSUE_TEMPLATE/config.yml` | Routes security reports and usage questions away from the issue tracker |
| `.github/PULL_REQUEST_TEMPLATE.md` | Asks which Word version a change was verified against |

The security policy spends most of its length on scope. ""The server deleted a file when told to"" is not a vulnerability in something whose job is to automate Word; ""a path argument escaped the named document"" is. Without saying so, that distinction is left to guesswork.

The bug template front-loads the Word build, the UI language and whether a dialog was open, because those three explain most reports - localization in particular breaks style and caption handling.

### Repository settings applied

- Dependabot vulnerability alerts and automated security fixes: **enabled**
- Private vulnerability reporting: **enabled** (this is what the SECURITY.md link points at)
- Discussions: **enabled** (referenced by the issue template config)
- Secret scanning and push protection: already on
- Branch protection on `main`: required checks `Build and test (Windows)` and `Pack NuGet tool`, strict up-to-date branches, linear history, no force pushes, no deletions, conversation resolution required. Admin enforcement is off so a single maintainer is not locked out.

### Not included

Dependabot configuration and `CONTRIBUTING.md` remain tracked in #3, as #29 asks.

Refs #29
