### PR TITLE
Add release automation, dependency updates and contributor guide

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+
+updates:
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      # These move together and are pinned against each other in Directory.Packages.props,
+      # so splitting them across PRs only produces builds that cannot restore.
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+      testing:
+        patterns:
+          - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "coverlet.*"
+    ignore:
+      # The PIA is versioned against the Office release, not semver, and a newer one does not
+      # mean a newer Word. Updating it is a deliberate decision.
+      - dependency-name: "Microsoft.Office.Interop.Word"
+      # Roslyn has to match the analyzer surface the .NET 9 SDK ships; a newer package silently
+      # breaks the source generator at consumer build time.
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+      - dependency-name: "Microsoft.CodeAnalysis.Analyzers"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Berlin
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,159 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build, without the leading v (e.g. 0.2.0). Produces artifacts only, never publishes."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build, test and publish
+    runs-on: windows-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          global-json-file: global.json
+
+      - name: Resolve version
+        id: version
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -like 'refs/tags/*') {
+            $version = $env:GITHUB_REF -replace '^refs/tags/v', ''
+            $publish = 'true'
+          } else {
+            $version = '${{ inputs.version }}'
+            $publish = 'false'
+          }
+
+          # A tag that is not a version is a mistake worth failing on rather than publishing.
+          if ($version -notmatch '^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$') {
+            throw "'$version' is not a valid version. Expected MAJOR.MINOR.PATCH with an optional prerelease suffix."
+          }
+
+          # A prerelease tag must not become the version users get from `dotnet tool install`.
+          $prerelease = if ($version -match '-') { 'true' } else { 'false' }
+
+          "version=$version" >> $env:GITHUB_OUTPUT
+          "publish=$publish" >> $env:GITHUB_OUTPUT
+          "prerelease=$prerelease" >> $env:GITHUB_OUTPUT
+          Write-Host "Releasing $version (publish=$publish, prerelease=$prerelease)"
+
+      - name: Restore
+        run: dotnet restore WordMcp.sln
+
+      - name: Build
+        run: >
+          dotnet build WordMcp.sln
+          --configuration Release
+          --no-restore
+          -p:Version=${{ steps.version.outputs.version }}
+
+      # Word integration tests are excluded: GitHub runners have no Office installation.
+      - name: Test
+        run: >
+          dotnet test WordMcp.sln
+          --configuration Release
+          --no-build
+          --filter "Category!=RequiresWord"
+          -p:Version=${{ steps.version.outputs.version }}
+
+      - name: Pack
+        run: >
+          dotnet pack src/WordMcp.McpServer/WordMcp.McpServer.csproj
+          --configuration Release
+          --no-build
+          -p:Version=${{ steps.version.outputs.version }}
+          --output ${{ github.workspace }}/artifacts
+
+      # The MCP registry rejects a server.json whose version disagrees with the package, and that
+      # only surfaces after publishing - so it is checked while the package is still local.
+      - name: Verify packaged server.json
+        shell: pwsh
+        run: |
+          $expected = '${{ steps.version.outputs.version }}'
+          $package = Get-ChildItem "${{ github.workspace }}/artifacts/*.nupkg" | Select-Object -First 1
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+          $zip = [System.IO.Compression.ZipFile]::OpenRead($package.FullName)
+          try {
+            $entry = $zip.Entries | Where-Object { $_.FullName -eq '.mcp/server.json' }
+            if (-not $entry) { throw "The package does not contain .mcp/server.json." }
+
+            $reader = New-Object System.IO.StreamReader($entry.Open())
+            $json = $reader.ReadToEnd() | ConvertFrom-Json
+          } finally {
+            $zip.Dispose()
+          }
+
+          if ($json.version -ne $expected) {
+            throw "server.json says $($json.version) but the package is $expected."
+          }
+          if ($json.packages[0].version -ne $expected) {
+            throw "server.json package entry says $($json.packages[0].version) but the package is $expected."
+          }
+
+          Write-Host "server.json matches $expected."
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: nuget-package
+          path: ${{ github.workspace }}/artifacts/*.nupkg
+
+      - name: Push to NuGet
+        if: steps.version.outputs.publish == 'true'
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if (-not $env:NUGET_API_KEY) {
+            throw "The NUGET_API_KEY repository secret is not set, so this release cannot be published."
+          }
+
+          dotnet nuget push "${{ github.workspace }}/artifacts/*.nupkg" `
+            --source https://api.nuget.org/v3/index.json `
+            --api-key $env:NUGET_API_KEY `
+            --skip-duplicate
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      - name: Create GitHub release
+        if: steps.version.outputs.publish == 'true'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # PowerShell does not expand wildcards for external commands, so the asset is resolved here.
+          $package = Get-ChildItem "${{ github.workspace }}/artifacts/*.nupkg" | Select-Object -First 1
+
+          $arguments = @(
+            'release', 'create', '${{ github.ref_name }}', $package.FullName,
+            '--title', 'v${{ steps.version.outputs.version }}',
+            '--generate-notes'
+          )
+          if ('${{ steps.version.outputs.prerelease }}' -eq 'true') { $arguments += '--prerelease' }
+
+          gh @arguments
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing
+
+Thanks for looking. This is a spare-time project, so the fastest way to get a change in is to make
+it easy to review.
+
+## Before you start
+
+Open an issue for anything larger than a bug fix. A new tool touches the source generator, the
+README and the test suite, and it is worth agreeing on the shape before you write it.
+
+## Setting up
+
+Requirements:
+
+* Windows 10 or 11
+* .NET 9 SDK
+* Microsoft Word 2016 or newer — the **desktop** version. The Microsoft Store version cannot be
+  automated through COM.
+
+```powershell
+git clone https://github.com/trsdn/mcp-server-word
+cd mcp-server-word
+dotnet build
+dotnet test --filter "Category!=RequiresWord"
+```
+
+## Running the tests
+
+The suite splits in two.
+
+```powershell
+# Everything that runs without Word. This is what CI runs.
+dotnet test --filter "Category!=RequiresWord"
+
+# Everything, including the tests that drive a real Word instance.
+dotnet test
+```
+
+The Word tests take roughly 35 seconds each, so a full run is around ten minutes. While iterating,
+narrow it down:
+
+```powershell
+dotnet test --filter "FullyQualifiedName~BookmarkIntegrationTests"
+```
+
+A failed integration run can leave `WINWORD.EXE` behind, which slows down or blocks the next run.
+Clear it first:
+
+```powershell
+Get-Process WINWORD -ErrorAction SilentlyContinue | Stop-Process -Force
+```
+
+## Adding a tool
+
+The MCP tool classes are generated. A new tool is three hand-written pieces:
+
+1. **The interface** in `src/WordMcp.Core/Commands/<Name>/I<Name>Commands.cs`, carrying
+   `[ServiceCategory]`, `[McpTool]` and one `[ServiceAction]` per action.
+2. **The COM implementation** next to it.
+3. **A property on `WordServices`** in `src/WordMcp.McpServer/WordServices.cs`. The generator maps
+   the interface type to that property, so without it nothing is emitted.
+
+The generated code lands in `src/WordMcp.McpServer/obj/generated` and is worth reading once, so the
+tool description you wrote is the one a client actually sees.
+
+Any new `Wd*` constant belongs in `src/WordMcp.ComInterop/ComInteropConstants.cs`, and any
+string-to-enum mapping in `src/WordMcp.Core/Utilities/WordConversions.cs`.
+
+### Tool descriptions are the interface
+
+An assistant sees only the description. Say what an action does, what the arguments mean, and where
+Word behaves in a way nobody would predict. The descriptions in the existing tools are long on
+purpose.
+
+## Conventions that the tests enforce
+
+* **Validate arguments before `batch.Execute`.** Anything checked outside the batch is testable
+  without Word, which is why the validation tests run in CI. Tests use `ThrowingBatch`: it throws
+  `NotSupportedException`, so a test expecting that exception is asserting "validation let this
+  through".
+* **Convert strings to Word constants before the batch too**, so a bad value produces a clear
+  message rather than a COM error from inside Word.
+* **Integration tests create their own document** when they change document-wide state, and are
+  marked `[Trait("Category", "RequiresWord")]`.
+* **Warnings are errors.** So are the xUnit analyzers — `Assert.Single(x.Where(...))` will not
+  compile.
+
+## Write down what Word did
+
+Most of the hard-won knowledge in this project is about Word behaving unexpectedly: a collection
+hanging off the Application instead of the Document, a parameter that silently changes the scope of
+an operation, a property that throws instead of returning empty.
+
+When you hit one, leave a comment at the line where it bites — not only in the pull request, which
+nobody reads a year later. If it is something a user of the server would trip over, add it to the
+"Known behaviour and pitfalls" section of the README as well.
+
+## Commits and pull requests
+
+* Write commit messages that explain why, not what. The diff already says what.
+* One logical change per pull request.
+* Fill in the pull request template, especially which Word version you verified against — CI cannot
+  run the integration tests, so that line is the only evidence they passed.
+
+## Releasing (maintainers)
+
+Releases are driven entirely by a tag. `Directory.Build.props` carries the fallback version for
+local builds; the published version comes from the tag, and a build target stamps it into
+`.mcp/server.json` so the MCP registry sees the same number as NuGet.
+
+```powershell
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+That runs `.github/workflows/release.yml`: build, test, pack, verify the stamped `server.json`,
+push to nuget.org and open a GitHub release with generated notes. A tag containing a hyphen
+(`v0.2.0-rc.1`) is published as a prerelease.
+
+Publishing needs a `NUGET_API_KEY` repository secret. Without it the push step fails and the
+release is not created — nothing half-published escapes. To rehearse the build without publishing,
+run the workflow manually from the Actions tab and pass a version; that path packs and uploads an
+artifact but never pushes.
+
+## Reporting bugs
+Use the [issue templates](https://github.com/trsdn/mcp-server-word/issues/new/choose). Include the
+Word build number and UI language; localization is behind a surprising share of the bugs here.
+
+Security problems do not go in the issue tracker — see [SECURITY.md](SECURITY.md).

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <!-- Common properties for all projects -->
+    <!-- The fallback for local builds. A release overrides it with a Version property taken from
+         the git tag, and AssemblyVersion/FileVersion follow it, so the reported version is honest. -->
     <Version>0.1.0</Version>
-    <AssemblyVersion>0.1.0.0</AssemblyVersion>
-    <FileVersion>0.1.0.0</FileVersion>
     <Authors>Torsten Mahr</Authors>
     <Company>Open Source Developer</Company>
     <Product>WordMcp</Product>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ mcp-word --version
 mcp-word --help
 ```
 
+To update or remove it later:
+
+```powershell
+dotnet tool update --global WordMcp.McpServer
+dotnet tool uninstall --global WordMcp.McpServer
+```
+
+To run an unreleased build instead, pack it locally and install from the output folder:
+
+```powershell
+dotnet pack src\WordMcp.McpServer\WordMcp.McpServer.csproj -c Release -o artifacts
+dotnet tool install --global --add-source .\artifacts WordMcp.McpServer
+```
+
 ## Client configuration
 
 The server speaks **stdio**.
@@ -414,7 +428,8 @@ Tests that need a real Word installation are marked `[Trait("Category", "Require
 ## Contributing
 
 Bug reports and feature requests go through the [issue templates](https://github.com/trsdn/mcp-server-word/issues/new/choose).
-Pull requests are welcome; the checklist in the PR template covers what the build enforces.
+Pull requests are welcome; [CONTRIBUTING.md](CONTRIBUTING.md) covers how to build, how to run the
+two halves of the test suite, and what it takes to add a tool.
 
 Please read the [Code of Conduct](CODE_OF_CONDUCT.md) first.
 

--- a/src/WordMcp.McpServer/WordMcp.McpServer.csproj
+++ b/src/WordMcp.McpServer/WordMcp.McpServer.csproj
@@ -38,6 +38,24 @@
     </PropertyGroup>
   </Target>
 
+  <!-- The MCP registry rejects a server.json whose version disagrees with the package version, so
+       the checked-in file is treated as a template and the version is stamped in at build time
+       from $(Version). Both occurrences are replaced: the server version and the package version. -->
+  <Target Name="_StampMcpServerJsonVersion"
+          BeforeTargets="AssignTargetPaths;GenerateNuspec"
+          Condition="Exists('$(MSBuildProjectDirectory)\.mcp\server.json')"
+          Inputs="$(MSBuildProjectDirectory)\.mcp\server.json"
+          Outputs="$(BaseIntermediateOutputPath)mcp\server.json">
+    <PropertyGroup>
+      <_McpServerJsonText>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\.mcp\server.json'))</_McpServerJsonText>
+      <_McpServerJsonText>$([System.Text.RegularExpressions.Regex]::Replace($(_McpServerJsonText), '"version": "[^"]*"', '"version": "$(Version)"'))</_McpServerJsonText>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(BaseIntermediateOutputPath)mcp\server.json"
+                      Lines="$(_McpServerJsonText)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true" />
+  </Target>
+
   <!-- Workaround for NETSDK1146: PackAsTool does not support net9.0-windows.
        See https://github.com/dotnet/sdk/issues/12055 -->
   <Target Name="HackBeforePackToolValidation" BeforeTargets="_PackToolValidation">
@@ -75,8 +93,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include=".mcp\server.json" Condition="Exists('.mcp\server.json')">
+    <Content Include="$(BaseIntermediateOutputPath)mcp\server.json" Link=".mcp\server.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>.mcp\server.json</TargetPath>
       <Pack>true</Pack>
       <PackagePath>.mcp/server.json</PackagePath>
     </Content>


### PR DESCRIPTION
Closes part of #3.

## What this does

Releases are now tag-driven. Pushing `v0.2.0` builds, tests, packs, pushes to nuget.org and opens a GitHub release with generated notes. A tag containing a hyphen (`v0.2.0-rc.1`) is published as a prerelease, so it never becomes what `dotnet tool install` picks by default.

The workflow can also be started manually with a version to rehearse the whole build. That path packs and uploads an artifact but never publishes.

## The version problem this fixes

The MCP registry rejects a `server.json` whose version disagrees with the package it describes, and that only becomes visible after the package is public. Two changes close that gap:

* `.mcp/server.json` is now a template. `_StampMcpServerJsonVersion` writes a copy into `obj` with the build version substituted into both version fields, and that copy is what gets packed and copied to the output directory.
* The workflow opens the finished `.nupkg` and checks both fields before pushing.

Separately, `AssemblyVersion` and `FileVersion` were pinned to `0.1.0.0`, so `-p:Version=` at release time changed the package but not the binary. A released `mcp-word --version` would have reported `0.1.0` forever. They now follow `Version`.

## Dependabot

Weekly, nuget and github-actions, grouped. Three packages are ignored on purpose:

* `Microsoft.Office.Interop.Word` — versioned along with Office, not semver.
* `Microsoft.CodeAnalysis.CSharp` and `.Analyzers` — have to match the Roslyn version in the .NET 9 SDK, otherwise the source generator stops building.

## CONTRIBUTING.md

Covers the build, the two halves of the test suite, the three hand-written pieces a new tool needs, and the conventions the analyzers enforce. Also a maintainer section on cutting a release.

## Action required

`NUGET_API_KEY` does not exist as a repository secret yet — only you can add it. Until then the push step fails and no release is created, so nothing gets half-published.

## Verification

* Clean rebuild from an empty `obj`: `dotnet pack -p:Version=1.2.3` produces a package whose `.mcp/server.json` reads `1.2.3` in both fields; without the property it reads `0.1.0`.
* `FileVersion` on the built assembly follows the passed version.
* 374 non-Word tests green, Release build with 0 warnings.
* `release.yml` parses as valid YAML; it has not run yet, since it only triggers on a tag.
