### PR TITLE
Add agent skill and architecture documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,9 @@ Get-Process WINWORD -ErrorAction SilentlyContinue | Stop-Process -Force
 
 ## Adding a tool
 
-The MCP tool classes are generated. A new tool is three hand-written pieces:
+The MCP tool classes are generated. [docs/architecture.md](docs/architecture.md) explains the
+layering; [docs/com-interop.md](docs/com-interop.md) covers the COM rules a new implementation has
+to follow. A new tool is three hand-written pieces:
 
 1. **The interface** in `src/WordMcp.Core/Commands/<Name>/I<Name>Commands.cs`, carrying
    `[ServiceCategory]`, `[McpTool]` and one `[ServiceAction]` per action.

--- a/README.md
+++ b/README.md
@@ -416,6 +416,15 @@ fails the build rather than reaching a client.
 
 Tests that need a real Word installation are marked `[Trait("Category", "RequiresWord")]` and are excluded in CI. Failed integration runs can leave orphaned `WINWORD.EXE` processes behind, which slow down or block later runs — clean them up with `Get-Process WINWORD | Stop-Process -Force` before re-running.
 
+### Further reading
+
+| Document | Covers |
+|---|---|
+| [docs/architecture.md](docs/architecture.md) | The layers, the request flow and how the tool layer is generated |
+| [docs/com-interop.md](docs/com-interop.md) | STA threading, releasing COM objects and the Word behaviour behind the pitfalls above |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Building, testing, adding a tool, cutting a release |
+| [skills/word-mcp/SKILL.md](skills/word-mcp/SKILL.md) | An agent-facing guide to using the tools in the right order |
+
 ## Troubleshooting
 
 | Symptom | Cause and fix |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,130 @@
+# Architecture
+
+Five projects, layered so that everything above the COM boundary is testable without Word running.
+
+```
+MCP client (VS Code, Claude Desktop, Copilot CLI)
+        │  stdio, JSON-RPC
+        ▼
+WordMcp.McpServer          tool classes, JSON responses, DI host
+        │                  ← generated at build time from the interfaces below
+        ▼
+WordMcp.Core               argument validation, command implementations, result models
+        │
+        ▼
+WordMcp.ComInterop         session manager, STA thread, Word COM objects
+        │
+        ▼
+WINWORD.EXE
+```
+
+`WordMcp.Generators.Mcp` and `WordMcp.Generators.Shared` are build-time only; they ship no runtime
+code.
+
+## The layers
+
+### WordMcp.ComInterop
+
+Owns everything that touches COM, and nothing else. `SessionManager` maps a `session_id` to an
+`IWordBatch`; a batch owns one Word `Application`, one open `Document` and one STA thread. Also
+here: the OLE message filter, extension and rights-protection validation, and the code that writes
+an empty `.docx` package without going through Word.
+
+Details are in [com-interop.md](com-interop.md).
+
+### WordMcp.Core
+
+One folder per tool under `Commands/`, each with an interface and an implementation:
+
+```
+Commands/Bookmark/IBookmarkCommands.cs    the contract the generator reads
+Commands/Bookmark/BookmarkCommands.cs     the COM work
+Models/BookmarkResults.cs                 the records that get serialized
+```
+
+The interface carries three kinds of attribute:
+
+| Attribute | On | Purpose |
+|---|---|---|
+| `[ServiceCategory]` | interface | Groups the actions under one tool |
+| `[McpTool]` | interface | Tool name and the description the client sees |
+| `[ServiceAction]` | method | Action name and description |
+
+Results are `record` types in `Models/`, serialized as camelCase with nulls omitted.
+
+**Validation happens before the batch.** Every implementation checks its arguments, converts
+strings to Word constants, and only then calls `batch.Execute`. That split is what makes the
+validation testable on a machine without Word — the tests pass a `ThrowingBatch` whose `Execute`
+throws, so "the call reached the batch" is the assertion that validation let the arguments
+through.
+
+### WordMcp.McpServer
+
+The host: stdio transport, DI, logging to stderr from `Warning` upwards (stdout carries the
+protocol, and MCP clients surface stderr as an error). `WordServices` exposes one static property
+per command interface, and `WordToolsBase` provides the shared serialization and the `try`/`catch`
+that turns any exception into a JSON error payload rather than a transport failure.
+
+`WordFileTool` is the only hand-written tool, because session lifecycle does not fit the
+generator's shape. The other fourteen are generated.
+
+## The generated tool layer
+
+A source generator reads the command interfaces and emits one MCP tool class per
+`[ServiceCategory]`. For each tool it produces a method with an `action` parameter, the union of
+all parameters of that tool's actions (each nullable, since a given action uses only some), a
+switch over the action names, and the `Execute` wrapper.
+
+The generator resolves the interface type to the `WordServices` property that provides it. **A new
+command interface without a matching property on `WordServices` produces nothing** — no error, no
+tool.
+
+`EmitCompilerGeneratedFiles` is on, so the output lands in `src/WordMcp.McpServer/obj/generated`
+and can be read like ordinary code. It is worth looking at once after adding a tool, to confirm
+that the description a client sees is the one that was written.
+
+Why generate: fifteen tools with close to seventy actions between them means the boilerplate is
+where the bugs would be, and a hand-written tool class drifts from its interface silently.
+
+## Request flow
+
+```
+tool call
+  → generated tool method
+      → WordToolsBase.Execute(tool, action, …)      catch → JSON error
+          → WordToolsBase.Batch(session_id)         → SessionManager
+              → XyzCommands.Action(batch, args)
+                  → validate arguments              throws here on bad input
+                  → batch.Execute(word => …)        marshalled to the STA thread
+                      → Word COM
+                  ← result record
+          ← JSON
+```
+
+Failures never travel as transport errors. Anything that throws comes back as
+
+```json
+{ "success": false, "isError": true, "tool": "text", "action": "Replace",
+  "errorType": "KeyNotFoundException", "errorMessage": "Session 'word-unknown' not found." }
+```
+
+which keeps a bad argument from looking like a broken server.
+
+## Testing
+
+| Project | Runs in CI | Covers |
+|---|---|---|
+| `WordMcp.Core.Tests` | validation tests only | argument validation, conversions, and — with Word — the real COM behaviour |
+| `WordMcp.McpServer.Tests` | yes | that the generated tools match the interfaces |
+
+Tests that need Word carry `[Trait("Category", "RequiresWord")]`; CI runs
+`--filter "Category!=RequiresWord"` because GitHub runners have no Office. That makes the
+integration suite a local gate, which is why the pull request template asks which Word version a
+change was verified against.
+
+## Versioning
+
+`Directory.Build.props` holds the fallback version. A release passes `-p:Version=` derived from the
+git tag, `AssemblyVersion` and `FileVersion` follow it, and a build target stamps it into a
+generated copy of `.mcp/server.json` — the MCP registry rejects a manifest whose version disagrees
+with the package. See [CONTRIBUTING.md](../CONTRIBUTING.md).

--- a/docs/com-interop.md
+++ b/docs/com-interop.md
@@ -1,0 +1,127 @@
+# Working with Word through COM
+
+Notes for anyone changing `WordMcp.ComInterop` or writing a new command. The user-facing quirks
+live in the README under "Known behaviour and pitfalls"; this is the layer below that.
+
+## Threading
+
+Word's automation interface is single-threaded apartment. Getting this wrong does not produce a
+clean error — it produces a `WINWORD.EXE` that never exits, or a call that fails once in fifty
+runs.
+
+Each `WordBatch` therefore owns:
+
+* **One STA thread**, created with `SetApartmentState(ApartmentState.STA)` before `Start()`.
+* **One work queue**, an unbounded `Channel<Action>`. `batch.Execute(...)` enqueues the delegate
+  and waits; the STA thread runs them one at a time.
+* **One OLE message filter**, registered on that thread and revoked on shutdown.
+
+Everything follows from this:
+
+* **All COM objects live on the STA thread.** A `Word.Document` handed out to a caller and touched
+  from a thread-pool thread is a marshalling bug waiting for a slow machine to expose it.
+* **Operations within a batch are serial.** For parallel work, open a second batch on a second
+  document.
+* **Never block the STA thread from inside an operation.** Waiting on another batch from within
+  `Execute` deadlocks.
+
+### The OLE message filter
+
+Word rejects incoming calls while it is busy with something else, and .NET surfaces that as
+`COMException` with `RPC_E_SERVERCALL_RETRYLATER`. `OleMessageFilter` intercepts the rejection and
+retries for a bounded time before giving up, which turns a common transient failure into a short
+pause. Without it, an operation running while Word is repaginating fails for no reason a user
+could act on.
+
+## Releasing COM objects
+
+`ComUtilities.Release(ref obj)` calls `Marshal.ReleaseComObject` and nulls the reference. It
+matters most inside loops:
+
+```csharp
+foreach (...)
+{
+    Word.Range? range = paragraph.Range;
+    try { /* work */ }
+    finally { ComUtilities.Release(ref range); }
+}
+```
+
+A leaked runtime callable wrapper keeps `WINWORD.EXE` alive after the session ends. The symptom is
+not an exception — it is a process in Task Manager and the next `file(open)` on the same document
+failing because the file is locked. Ranges, paragraphs, tables and cells obtained during iteration
+are the usual culprits.
+
+`ComUtilities.TryQuitWord` swallows errors on purpose: shutdown must not throw over a Word that
+has already gone away.
+
+## Long dotted chains lie
+
+`doc.Paragraphs[1].Range.Font.Bold = true` creates four wrappers and releases none of them. Split
+the chain when it runs more than a couple of times.
+
+## Where the collection hangs matters
+
+Some Word collections live on the `Application`, not on the `Document` — `Application.Options`,
+the dialogs, the recent files list. Reading one of those changes global Word state that outlives
+the session, so treat anything on `Application` as shared and restore it if you change it.
+
+The mirror image is that several document-wide operations silently cover the body only.
+`Document.Fields.Update()` and `Document.AcceptAllRevisions()` both skip headers and footers, which
+is why `field(update-all)` and `revision(accept)` iterate `Sections` and handle each section's
+`Headers` and `Footers` on top of the document-wide call.
+
+## Constants and conversions
+
+Word constants are `int` in this codebase, declared in `ComInteropConstants`, not taken from the
+interop enums — the enum names are long, inconsistently cased, and the numeric values are the
+documented part of the API anyway.
+
+String-to-constant conversion belongs in `WordConversions` and must happen **before**
+`batch.Execute`, so an unknown value produces a message naming the valid options rather than a
+COM error from inside Word. This is also what makes it testable without Word.
+
+Style names go through `WordStyles`: built-in English names are translated to Word's
+language-independent style ids, so `Heading 1` works on a German install. Anything unrecognised is
+passed through, which is how custom and localized styles are addressed.
+
+## Documents Word will not open cleanly
+
+Checked before Word is launched, because Word's own failure mode is a modal dialog on a hidden
+window — which looks like a hang:
+
+* **Unsupported extension** — `FileAccessValidator.ValidateExtension`.
+* **IRM/AIP protection** — an encrypted `.docx` is an OLE2 compound document rather than a ZIP, so
+  the file signature gives it away. Legacy `.doc` is legitimately OLE2, hence the extension check
+  first.
+* **Already open** — an exclusive-access probe, reported as a message telling the user to close
+  the document.
+
+## Creating documents
+
+`file(create)` writes an empty Open XML package itself (`EmptyDocumentFactory`) and then opens it.
+Creating through `Documents.Add` plus `SaveAs` is unreliable on machines signed in to Microsoft
+365: AutoSave claims the new document for OneDrive and quietly ignores the requested local path.
+
+## Timeouts
+
+Two of them, both in `ComInteropConstants`: a startup timeout for the Word instance and a
+per-operation timeout (five minutes by default). An operation that exceeds it is almost always a
+modal dialog waiting on an invisible desktop, so the error message says so.
+
+## Debugging
+
+* **Leftover processes**: `Get-Process WINWORD | Stop-Process -Force` before an integration run. A
+  failed run leaves Word behind, and the next run then fails on a file lock instead of the real
+  problem.
+* **Watch it work**: batches take a `visible` flag. Seeing the document change makes an unexpected
+  dialog obvious.
+* **`HRESULT 0x800A...`** is Word saying no, not .NET failing. The number is rarely specific;
+  `0x800A11FD` ("this command is not available") in particular covers everything from a wrong
+  selection to a feature disabled by the document's protection state.
+
+## When Word behaves oddly, write it down
+
+Most of the hard-won knowledge here is behavioural, and none of it is discoverable from the type
+signatures. Leave a comment at the line where the surprise bites, and add a bullet to the README
+when a user of the server would trip over it too.

--- a/skills/word-mcp/SKILL.md
+++ b/skills/word-mcp/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: word-mcp
+description: >
+  Automate Microsoft Word on Windows through the WordMcp MCP server. Use when creating, reading,
+  or editing Word documents: text, paragraphs, tables, images, styles, lists, sections, headers
+  and footers, fields and tables of contents, comments, tracked changes and bookmarks. Can render
+  a page as an image to check layout.
+  Triggers: Word, document, docx, report, letter, memo, table of contents, tracked changes,
+  comments, bookmarks, headers, footers.
+---
+
+# Word MCP Server Skill
+
+Fifteen tools, each taking an `action` parameter. The tool descriptions are complete; this file
+covers the workflow, the ordering rules that are not obvious, and the places where Word behaves
+in a way nobody would guess.
+
+## Preconditions
+
+- Windows with Microsoft Word 2016 or newer, **desktop** edition. The Microsoft Store version
+  cannot be automated.
+- Absolute paths only: `C:\Users\me\Documents\report.docx`.
+- The document must not already be open in Word. Ask the user to close it rather than guessing.
+- Word runs invisibly and is shut down with the session.
+
+## The one rule that matters
+
+**Everything runs inside a session.** `file(open)` or `file(create)` returns a `session_id` that
+every other call needs, and `file(close)` is what actually writes the document and releases Word.
+
+```
+file(open|create) → session_id → edit → file(save) → file(close, save: true)
+```
+
+A session left open holds a `WINWORD.EXE` process and an exclusive lock on the file. Close it even
+when the work failed halfway through.
+
+## Building a document
+
+Order matters more than it looks:
+
+1. `file(create)` — an empty document.
+2. Content first: `paragraph(add)` with `style: "Heading 1"` for structure, `text(append)`,
+   `table(create)`, `image(insert)`.
+3. Formatting second: `style(create|modify)`, `list(apply)`, `paragraph(set-alignment)`.
+4. Page setup: `section(page-setup)`, then `header-footer(set)`, then `field(insert-page-number)`.
+5. Fields last: `field(insert-toc)` then `field(update-all)`. A table of contents inserted before
+   the headings exist stays empty.
+6. `file(close, save: true)`.
+
+## Reading a document
+
+- `document(get-info)` for the counts, `paragraph(list)` for the structure. Start there rather
+  than pulling the entire text with `text(get)`.
+- `text(find)` returns character positions that `text(format)` and `text(get)` accept.
+- `screenshot(page)` answers layout questions — does the table fit, where does the page break, is
+  the header on the right page — far more reliably than any measurement.
+
+## Indexes, and how to avoid getting burned by them
+
+Paragraph, table, image, comment and revision indexes are **1-based** and they **shift** on every
+insertion or deletion. Two habits keep this from causing damage:
+
+- Delete from the back to the front, or `list` again after every delete.
+- When a passage has to be referred to more than once, `bookmark(add)` it. Bookmarks survive edits
+  elsewhere; indexes do not.
+
+## Recipes
+
+**Report with a table of contents**
+
+```
+file(create, path: "C:\\temp\\report.docx")
+paragraph(add, text: "Quarterly Report", style: "Title")
+paragraph(add, text: "Summary", style: "Heading 1")
+text(append, text: "Revenue grew by fifteen percent.", as_new_paragraph: true)
+field(insert-toc)          # after the headings exist
+field(update-all)
+file(close, save: true)
+```
+
+**Review pass**
+
+```
+revision(set-tracking, enabled: true)     # before the edits, it is not retroactive
+text(replace, find: "fifteen", replace: "seventeen")
+comment(add, paragraph_index: 4, text: "Source?", anchor_text: "seventeen percent")
+revision(list)
+```
+
+**Check the layout**
+
+```
+screenshot(page, page: 2)                 # dpi 150 by default; 96 is enough for a quick look
+```
+
+Only pass `include_image: true` when the image is actually going to be looked at — otherwise it
+just fills the context window.
+
+## Non-obvious behaviour
+
+**Ordering**
+
+- `field(insert-toc)` on a document without heading styles produces an empty table of contents.
+  Apply `Heading 1`/`Heading 2` first, then `field(update-toc)`.
+- `section(page-setup)` applies the paper size before the margins, because changing the paper size
+  resets them. Without a `section_index` it hits every section.
+- `revision(set-tracking)` is not retroactive.
+
+**Scope**
+
+- `field(update-all)` and `revision(accept|reject)` without an index deliberately walk headers and
+  footers too; Word's own document-wide calls cover the body only.
+- `image` covers inline pictures only. Text boxes, floating shapes and charts are invisible to it.
+- Headers are inherited between sections until something is written to them. `header-footer(set)`
+  with a `section_index` breaks that link for you.
+- `first-page` and `even-pages` headers only render once the section switch is on, which
+  `header-footer(set)` also handles.
+
+**Traps**
+
+- `document(save-as)` **also saves the original**, because Word has no format-changing "save a
+  copy". Use `document(export-pdf)` when the original must stay untouched.
+- `comment(resolve)` usually fails on Microsoft 365: comments added through the API are unposted
+  drafts and a draft cannot be marked done. Delete the comment instead.
+- `table(read)` returns merged cells as empty strings.
+- Bookmark names must start with a letter and contain only letters, digits and underscores.
+- Styles are addressed in English (`Heading 1`) but Word reports them localized. `style(list)`
+  returns both `name` and `english_name` — send `english_name` back when it is there.
+- Colours are hex RGB (`#0078D4`). Sizes and margins are in points (72 pt = 1 inch,
+  1 cm = 28.35 pt).
+
+## When something fails
+
+Errors come back as JSON with `errorType` and `errorMessage`, not as a transport failure, so the
+message is worth reading before retrying.
+
+| Message | What to do |
+|---|---|
+| `Session '…' not found` | The session was closed. Open the document again. |
+| `The file is already open in Word` | Ask the user to close it. |
+| Call times out | A Word dialog is waiting for input on the desktop. |
+| `Word is not installed or not registered for COM` | Run `file(action: "test")` to confirm, then stop; this cannot be worked around. |


### PR DESCRIPTION
Closes #3.

## Why

The README documents what every tool does; the tool descriptions themselves reach the client. What neither covers is **order**, and that is where an agent goes wrong in practice:

* inserting a table of contents before any heading exists, then reporting an empty one
* turning on change tracking after making the edits
* reusing a paragraph index after a delete has shifted everything below it

`skills/word-mcp/SKILL.md` is written against exactly those failures: the session rule, the build order, the index rule, four short recipes, and the traps grouped by ordering / scope / behaviour. It stays under 150 lines so it is worth loading into a context window.

## docs/

`architecture.md` — the five projects, what each layer owns, the request flow from tool call to COM and back, why the tool layer is generated and what happens when a `WordServices` property is forgotten (nothing is emitted, silently).

`com-interop.md` — the part that is genuinely not recoverable from reading the code:

* why every batch owns an STA thread with its own work queue and OLE message filter
* why a leaked `Range` shows up as a locked file on the *next* run rather than as an exception
* why validation and string-to-constant conversion happen before `batch.Execute`
* why `field(update-all)` iterates sections instead of trusting `Document.Fields.Update()`
* why `file(create)` writes the .docx package itself instead of asking Word

## A deviation from the epic

#3 asked for `SKILL.md` to be generated from the interface attributes, the way the tool classes are. I dropped that. The valuable content is ordering and surprises, and neither is derivable from a method signature — a generated file would have restated the tool descriptions the client already receives, and the useful half would have lived in a template that is harder to edit than a markdown file.

## Verification

* YAML frontmatter parses; `name` and `description` present.
* Every relative link in the five touched markdown files resolves to a file that exists.
* Claims checked against the source rather than from memory — one draft asserted that `field(update-all)` walks `StoryRanges`; it iterates `Sections` and their `Headers`/`Footers`, and the text was corrected.
* Docs only, no code touched.
