### PR TITLE
Add the named pipe host and client for the session service

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <!-- Microsoft Extensions for MCP Server -->
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
     <!-- Pinned to 10.0.3 because ModelContextProtocol 0.9.0-preview.2 requires it -->
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.4" />

--- a/README.md
+++ b/README.md
@@ -95,6 +95,22 @@ file(open|create) ──► session_id ──► text / paragraph / table / docu
 * The document must not be open in Word already — WordMcp needs exclusive access.
 * Word runs invisibly in the background and is terminated when the session closes.
 
+### The session service
+
+Sessions normally live inside the MCP server process and disappear with it. `WordMcp.Service.exe`
+is an optional background daemon that holds them instead, so a session survives a restarted client
+and can be shared by several of them:
+
+```
+WordMcp.Service.exe --daemon [--idle-minutes 30]   # listen until idle or stopped
+WordMcp.Service.exe --status                       # what is it doing?
+WordMcp.Service.exe --stop                         # save open documents and exit
+```
+
+Starting it by hand is rarely necessary — a client configured to use it starts it on demand. The
+pipe it listens on embeds your SID and is ACL'd to it, so sessions are never shared between
+accounts. It exits on its own once no session has been open for the idle timeout.
+
 ---
 
 ## Tools

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,25 @@ timer, which keeps it testable without waiting. An open session always counts as
 long ago it was touched: closing Word underneath a client that still holds a session id turns a
 dormant workflow into a broken one.
 
+### The daemon
+
+`WordMcp.Service` is also an executable. `--daemon` runs `ServiceHost`, which accepts pipe
+connections and feeds each line to `WordMcpService`; `--status` and `--stop` are thin clients
+against a running one. `ServiceClient` is the other side, and starting it is the interesting part:
+
+- **A missing service is not an error.** `SendAsync` first tries to connect; if nothing answers and
+  auto-start is on, it spawns the daemon, waits for it to listen, and retries. Callers never have
+  to know whether a service was already running.
+- **One connection per request.** Locally that costs microseconds and buys reconnect for free: a
+  daemon that exited on its idle timeout is simply started again by the next call, with no stale
+  connection state to reason about.
+- **Single instance via a named mutex, not the pipe.** Windows happily allows several servers on
+  one pipe name, so two daemons would both appear to start and each client would see half the
+  sessions. `WordMcp-host-{pipeName}` settles it before the pipe is ever created.
+
+The accept loop parks in `WaitForConnectionAsync`, which no cancellation token can interrupt on
+Windows, so the watchdog that notices shutdown or idleness wakes it with a throwaway connection.
+
 ## The generated tool layer
 
 A source generator reads the command interfaces and emits one MCP tool class per

--- a/src/WordMcp.Service/Program.cs
+++ b/src/WordMcp.Service/Program.cs
@@ -1,0 +1,267 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace WordMcp.Service;
+
+/// <summary>
+/// Command line entry point of the Word session service.
+/// </summary>
+public static class Program
+{
+    /// <summary>
+    /// Runs the requested mode.
+    /// </summary>
+    /// <param name="args">Command line arguments.</param>
+    /// <returns>0 on success, 1 on failure.</returns>
+    public static async Task<int> Main(string[] args)
+    {
+        ArgumentNullException.ThrowIfNull(args);
+
+        var options = CommandLine.Parse(args);
+
+        return options.Mode switch
+        {
+            RunMode.Help => Show(Usage()),
+            RunMode.Version => Show($"Word session service v{VersionText}"),
+            RunMode.Daemon => await RunDaemonAsync(options).ConfigureAwait(false),
+            RunMode.Status => await ShowStatusAsync(options).ConfigureAwait(false),
+            RunMode.Stop => await StopAsync(options).ConfigureAwait(false),
+            _ => Show(Usage())
+        };
+    }
+
+    private static string VersionText
+        => typeof(Program).Assembly.GetName().Version?.ToString() ?? "0.1.0";
+
+    private static int Show(string text)
+    {
+        Console.WriteLine(text);
+        return 0;
+    }
+
+    private static async Task<int> RunDaemonAsync(CommandLineOptions options)
+    {
+        using var loggerFactory = LoggerFactory.Create(builder => builder
+            .AddSimpleConsole(console => console.SingleLine = true)
+            .SetMinimumLevel(options.Verbose ? LogLevel.Information : LogLevel.Warning));
+
+        var logger = loggerFactory.CreateLogger("WordMcp.Service");
+
+        using var service = new WordMcpService(logger, options.IdleTimeout);
+        using var host = ServiceHost.TryCreate(service, options.PipeName, logger);
+
+        if (host is null)
+        {
+            // Not an error: the caller wanted a service on that pipe and there is one.
+            Console.Error.WriteLine($"A Word session service is already listening on '{options.PipeName}'.");
+            return 0;
+        }
+
+        using var stopping = new CancellationTokenSource();
+        Console.CancelKeyPress += (_, e) =>
+        {
+            e.Cancel = true;
+            stopping.Cancel();
+        };
+
+        try
+        {
+            await host.RunAsync(stopping.Token).ConfigureAwait(false);
+            return 0;
+        }
+        catch (OperationCanceledException)
+        {
+            return 0;
+        }
+#pragma warning disable CA1031 // Top-level handler must not crash the process
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[WordMcp.Service] Fatal error: {ex.Message}");
+            return 1;
+        }
+#pragma warning restore CA1031
+    }
+
+    private static async Task<int> ShowStatusAsync(CommandLineOptions options)
+    {
+        using var client = new ServiceClient(options.PipeName, new ServiceClientOptions { AutoStart = false });
+
+        var response = await client.SendAsync(new ServiceRequest { Command = "service.status", Source = "cli" })
+            .ConfigureAwait(false);
+
+        if (!response.Success)
+        {
+            Console.WriteLine($"Not running on '{options.PipeName}'.");
+            return 1;
+        }
+
+        var status = ServiceProtocol.Deserialize<ServiceStatus>(response.Result!)!;
+
+        Console.WriteLine(string.Create(CultureInfo.InvariantCulture, $"""
+            Word session service v{status.Version}
+              pipe          {options.PipeName}
+              process       {status.ProcessId}
+              sessions      {status.SessionCount}
+              started       {status.StartedAt:u}
+              last activity {status.LastActivityAt:u}
+              idle timeout  {status.IdleTimeout}
+            """));
+
+        return 0;
+    }
+
+    private static async Task<int> StopAsync(CommandLineOptions options)
+    {
+        using var client = new ServiceClient(options.PipeName, new ServiceClientOptions { AutoStart = false });
+
+        var response = await client.SendAsync(new ServiceRequest { Command = "service.shutdown", Source = "cli" })
+            .ConfigureAwait(false);
+
+        Console.WriteLine(response.Success
+            ? "The Word session service is shutting down; open documents are saved first."
+            : $"Not running on '{options.PipeName}'.");
+
+        return response.Success ? 0 : 1;
+    }
+
+    private static string Usage() => $"""
+        Word session service v{VersionText}
+
+        Holds Microsoft Word sessions so several clients can share one open document.
+
+        Usage:
+          WordMcp.Service.exe --daemon [--pipe NAME] [--idle-minutes N] [--verbose]
+          WordMcp.Service.exe --status [--pipe NAME]
+          WordMcp.Service.exe --stop   [--pipe NAME]
+
+        Options:
+          --daemon          Listen for clients until idle or stopped
+          --status          Print what a running service is doing
+          --stop            Ask a running service to save and exit
+          --pipe NAME       Pipe to use (default: the per-user service pipe)
+          --idle-minutes N  Exit after N minutes without sessions (default: {(int)WordMcpService.DefaultIdleTimeout.TotalMinutes})
+          --verbose         Log informational messages as well as warnings
+          -h, --help        Show this help
+          -v, --version     Show version information
+
+        The pipe name embeds the current user's SID and is ACL'd to that user, so
+        sessions are never shared across accounts.
+        """;
+}
+
+/// <summary>
+/// What the process was asked to do.
+/// </summary>
+public enum RunMode
+{
+    /// <summary>Print usage.</summary>
+    Help,
+
+    /// <summary>Print the version.</summary>
+    Version,
+
+    /// <summary>Listen for clients.</summary>
+    Daemon,
+
+    /// <summary>Report what a running service is doing.</summary>
+    Status,
+
+    /// <summary>Ask a running service to save and exit.</summary>
+    Stop
+}
+
+/// <summary>
+/// Parsed command line.
+/// </summary>
+public sealed class CommandLineOptions
+{
+    /// <summary>
+    /// Gets the requested mode.
+    /// </summary>
+    public RunMode Mode { get; init; }
+
+    /// <summary>
+    /// Gets the pipe to listen on or talk to.
+    /// </summary>
+    public required string PipeName { get; init; }
+
+    /// <summary>
+    /// Gets the idle timeout, or <c>null</c> to use the service default.
+    /// </summary>
+    public TimeSpan? IdleTimeout { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether informational messages are logged.
+    /// </summary>
+    public bool Verbose { get; init; }
+}
+
+/// <summary>
+/// Turns arguments into <see cref="CommandLineOptions"/>.
+/// </summary>
+public static class CommandLine
+{
+    /// <summary>
+    /// Parses arguments. Unknown arguments select the help mode rather than failing, because a
+    /// service that refuses to explain itself is worse than one that prints usage.
+    /// </summary>
+    /// <param name="args">Raw arguments.</param>
+    /// <returns>The parsed options.</returns>
+    public static CommandLineOptions Parse(string[] args)
+    {
+        var mode = RunMode.Help;
+        string? pipeName = null;
+        TimeSpan? idleTimeout = null;
+        var verbose = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i].ToLowerInvariant())
+            {
+                case "--daemon":
+                    mode = RunMode.Daemon;
+                    break;
+                case "--status":
+                    mode = RunMode.Status;
+                    break;
+                case "--stop":
+                    mode = RunMode.Stop;
+                    break;
+                case "-v":
+                case "--version":
+                    mode = RunMode.Version;
+                    break;
+                case "-h":
+                case "--help":
+                case "-?":
+                case "/?":
+                    mode = RunMode.Help;
+                    break;
+                case "--verbose":
+                    verbose = true;
+                    break;
+                case "--pipe" when i + 1 < args.Length:
+                    pipeName = args[++i];
+                    break;
+                case "--idle-minutes" when i + 1 < args.Length:
+                    if (int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out var minutes) &&
+                        minutes >= 0)
+                    {
+                        idleTimeout = TimeSpan.FromMinutes(minutes);
+                    }
+
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return new CommandLineOptions
+        {
+            Mode = mode,
+            PipeName = string.IsNullOrWhiteSpace(pipeName) ? ServiceSecurity.GetServicePipeName() : pipeName,
+            IdleTimeout = idleTimeout,
+            Verbose = verbose
+        };
+    }
+}

--- a/src/WordMcp.Service/ServiceClient.cs
+++ b/src/WordMcp.Service/ServiceClient.cs
@@ -1,0 +1,308 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace WordMcp.Service;
+
+/// <summary>
+/// Options that control how a <see cref="ServiceClient"/> reaches its daemon.
+/// </summary>
+public sealed class ServiceClientOptions
+{
+    /// <summary>
+    /// Gets the time allowed for a single connection attempt.
+    /// </summary>
+    public TimeSpan ConnectTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Gets the time allowed for a whole request, including waiting for Word.
+    /// </summary>
+    /// <remarks>
+    /// Generous on purpose. A Word operation carries its own timeout, and the pipe expiring first
+    /// would replace a precise error with a vague one.
+    /// </remarks>
+    public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromHours(2);
+
+    /// <summary>
+    /// Gets a value indicating whether the client may start a daemon that is not running.
+    /// </summary>
+    public bool AutoStart { get; init; } = true;
+
+    /// <summary>
+    /// Gets the time to wait for a freshly started daemon to answer.
+    /// </summary>
+    public TimeSpan StartupTimeout { get; init; } = TimeSpan.FromSeconds(20);
+
+    /// <summary>
+    /// Gets the daemon executable. Probed next to the running assembly when not set.
+    /// </summary>
+    public string? ExecutablePath { get; init; }
+
+    /// <summary>
+    /// Gets the idle timeout handed to a daemon this client starts.
+    /// </summary>
+    public TimeSpan? IdleTimeout { get; init; }
+}
+
+/// <summary>
+/// Talks to a <see cref="ServiceHost"/> over a named pipe, starting the daemon when needed.
+/// </summary>
+/// <remarks>
+/// <para>Every request gets its own connection. That costs a few hundred microseconds on local
+/// IPC and buys reconnection for free: a daemon that exited on its idle timeout is simply started
+/// again by the next call, with no stale-socket state to reason about.</para>
+/// <para>Transport failures are returned as unsuccessful responses rather than thrown, so callers
+/// handle "the service is gone" the same way they handle "the command failed".</para>
+/// </remarks>
+public sealed class ServiceClient : IDisposable
+{
+    private readonly SemaphoreSlim _startGate = new(1, 1);
+    private readonly ServiceClientOptions _options;
+    private readonly ILogger? _logger;
+    private int _disposed;
+
+    /// <summary>
+    /// Creates a client for a pipe.
+    /// </summary>
+    /// <param name="pipeName">Name of the pipe, usually <see cref="ServiceSecurity.GetServicePipeName"/>.</param>
+    /// <param name="options">Connection and auto-start behaviour.</param>
+    /// <param name="logger">Optional logger for diagnostics.</param>
+    public ServiceClient(string pipeName, ServiceClientOptions? options = null, ILogger? logger = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(pipeName);
+
+        PipeName = pipeName;
+        _options = options ?? new ServiceClientOptions();
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Gets the pipe this client talks to.
+    /// </summary>
+    public string PipeName { get; }
+
+    /// <summary>
+    /// Sends one command and waits for its result.
+    /// </summary>
+    /// <param name="request">The command to run.</param>
+    /// <param name="cancellationToken">Token that cancels the call.</param>
+    /// <returns>The service's response, or a failed response describing the transport problem.</returns>
+    public async Task<ServiceResponse> SendAsync(ServiceRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) == 1, this);
+
+        var response = await TrySendAsync(request, cancellationToken).ConfigureAwait(false);
+        if (response is not null)
+        {
+            return response;
+        }
+
+        if (!_options.AutoStart)
+        {
+            return ServiceResponse.Fail(
+                $"No Word session service is listening on '{PipeName}'.", nameof(IOException));
+        }
+
+        if (!await EnsureRunningAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return ServiceResponse.Fail(
+                "Could not start the Word session service.", nameof(InvalidOperationException));
+        }
+
+        return await TrySendAsync(request, cancellationToken).ConfigureAwait(false)
+            ?? ServiceResponse.Fail(
+                "The Word session service started but did not answer.", nameof(TimeoutException));
+    }
+
+    /// <summary>
+    /// Checks whether a service is answering on the pipe. Never starts one.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels the call.</param>
+    /// <returns><c>true</c> when a service answered.</returns>
+    public async Task<bool> PingAsync(CancellationToken cancellationToken = default)
+    {
+        var response = await TrySendAsync(
+            new ServiceRequest { Command = "service.ping", Source = "client" },
+            cancellationToken).ConfigureAwait(false);
+
+        return response?.Success == true;
+    }
+
+    /// <summary>
+    /// Makes sure a daemon is running, starting one if necessary.
+    /// </summary>
+    /// <param name="cancellationToken">Token that cancels the call.</param>
+    /// <returns><c>true</c> when a service is answering by the time this returns.</returns>
+    public async Task<bool> EnsureRunningAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) == 1, this);
+
+        if (await PingAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return true;
+        }
+
+        // Two callers racing here would spawn two daemons; the loser's would exit on the single
+        // instance mutex, but starting Word twice is expensive enough to be worth avoiding.
+        await _startGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (await PingAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return true;
+            }
+
+            if (!TryStartDaemon())
+            {
+                return false;
+            }
+
+            return await WaitForServiceAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _startGate.Release();
+        }
+    }
+
+    /// <summary>
+    /// Locates the daemon executable.
+    /// </summary>
+    /// <returns>The full path, or <c>null</c> when it could not be found.</returns>
+    public static string? FindExecutable()
+    {
+        var candidates = new[]
+        {
+            Path.Combine(AppContext.BaseDirectory, "WordMcp.Service.exe"),
+            Path.Combine(Path.GetDirectoryName(Environment.ProcessPath) ?? AppContext.BaseDirectory, "WordMcp.Service.exe")
+        };
+
+        return Array.Find(candidates, File.Exists);
+    }
+
+    /// <summary>
+    /// Releases the client's resources. The daemon keeps running.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.CompareExchange(ref _disposed, 1, 0) == 0)
+        {
+            _startGate.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Performs one round trip.
+    /// </summary>
+    /// <returns>The response, or <c>null</c> when no service could be reached.</returns>
+    private async Task<ServiceResponse?> TrySendAsync(ServiceRequest request, CancellationToken cancellationToken)
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(_options.RequestTimeout);
+
+        try
+        {
+            await using var pipe = ServiceSecurity.CreateClient(PipeName);
+            await pipe.ConnectAsync((int)_options.ConnectTimeout.TotalMilliseconds, timeout.Token)
+                .ConfigureAwait(false);
+
+            await using var writer = new StreamWriter(pipe, new UTF8Encoding(false), 4096, leaveOpen: true);
+            await writer.WriteLineAsync(ServiceProtocol.Serialize(request).AsMemory(), timeout.Token)
+                .ConfigureAwait(false);
+            await writer.FlushAsync(timeout.Token).ConfigureAwait(false);
+
+            using var reader = new StreamReader(pipe, new UTF8Encoding(false), false, 4096, leaveOpen: true);
+            var line = await reader.ReadLineAsync(timeout.Token).ConfigureAwait(false);
+
+            if (line is null)
+            {
+                return ServiceResponse.Fail(
+                    "The Word session service closed the connection without answering.", nameof(IOException));
+            }
+
+            return ServiceProtocol.Deserialize<ServiceResponse>(line)
+                ?? ServiceResponse.Fail("The Word session service sent an empty answer.", nameof(IOException));
+        }
+        catch (TimeoutException)
+        {
+            // No listener on the pipe. Reported as "unreachable" so the caller can start one.
+            return null;
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        {
+            return ServiceResponse.Fail(
+                string.Create(CultureInfo.InvariantCulture, $"The request timed out after {_options.RequestTimeout}."),
+                nameof(TimeoutException));
+        }
+        catch (IOException)
+        {
+            // The daemon died between connect and answer; treat it as unreachable and retry.
+            return null;
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            return ServiceResponse.Fail(
+                $"Access to the Word session service was denied: {ex.Message}", nameof(UnauthorizedAccessException));
+        }
+    }
+
+    private bool TryStartDaemon()
+    {
+        var executable = _options.ExecutablePath ?? FindExecutable();
+        if (executable is null)
+        {
+            _logger?.LogWarning("WordMcp.Service.exe was not found next to the running application");
+            return false;
+        }
+
+        var startInfo = new ProcessStartInfo(executable)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WindowStyle = ProcessWindowStyle.Hidden
+        };
+
+        startInfo.ArgumentList.Add("--daemon");
+        startInfo.ArgumentList.Add("--pipe");
+        startInfo.ArgumentList.Add(PipeName);
+
+        if (_options.IdleTimeout is { } idle)
+        {
+            startInfo.ArgumentList.Add("--idle-minutes");
+            startInfo.ArgumentList.Add(((int)idle.TotalMinutes).ToString(CultureInfo.InvariantCulture));
+        }
+
+        try
+        {
+            using var process = Process.Start(startInfo);
+            _logger?.LogInformation("Started the Word session service (pid {ProcessId})", process?.Id);
+            return process is not null;
+        }
+#pragma warning disable CA1031 // A failed start is reported to the caller, not thrown
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Could not start {Executable}", executable);
+            return false;
+        }
+#pragma warning restore CA1031
+    }
+
+    private async Task<bool> WaitForServiceAsync(CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + _options.StartupTimeout;
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await PingAsync(cancellationToken).ConfigureAwait(false))
+            {
+                return true;
+            }
+
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+        }
+
+        return false;
+    }
+}

--- a/src/WordMcp.Service/ServiceHost.cs
+++ b/src/WordMcp.Service/ServiceHost.cs
@@ -1,0 +1,250 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+
+namespace WordMcp.Service;
+
+/// <summary>
+/// Serves a <see cref="WordMcpService"/> over a named pipe.
+/// </summary>
+/// <remarks>
+/// <para>Each accepted connection is handled on its own task and may carry many requests, so a
+/// client can hold the pipe open for a whole workflow. A fresh listening instance is created
+/// before the previous connection is handed off, which keeps a second client from being refused
+/// while the first is busy.</para>
+/// <para>The host stops when a client sends <c>service.shutdown</c>, when the service has been
+/// idle past its timeout, or when the caller cancels. Requests are not serialized here: the
+/// service itself decides what needs a lock, and Word calls are already serialized per session on
+/// that session's STA thread.</para>
+/// </remarks>
+public sealed class ServiceHost : IDisposable
+{
+    private readonly WordMcpService _service;
+    private readonly ILogger? _logger;
+    private readonly Mutex? _singleInstance;
+    private int _disposed;
+
+    private ServiceHost(WordMcpService service, string pipeName, Mutex? singleInstance, ILogger? logger)
+    {
+        _service = service;
+        _logger = logger;
+        _singleInstance = singleInstance;
+        PipeName = pipeName;
+    }
+
+    /// <summary>
+    /// Gets the pipe this host listens on.
+    /// </summary>
+    public string PipeName { get; }
+
+    /// <summary>
+    /// How often the host checks whether it should stop.
+    /// </summary>
+    public static TimeSpan StopPollInterval { get; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Claims the pipe name for this process and creates a host for it.
+    /// </summary>
+    /// <param name="service">The service whose commands are served.</param>
+    /// <param name="pipeName">Name of the pipe to listen on.</param>
+    /// <param name="logger">Optional logger for diagnostics.</param>
+    /// <returns>The host, or <c>null</c> when another process already serves this pipe.</returns>
+    /// <remarks>
+    /// A named mutex, not the pipe itself, decides who wins: Windows happily allows several server
+    /// instances on one pipe name, so two daemons would otherwise both appear to start and clients
+    /// would be split between them, each seeing half the sessions.
+    /// </remarks>
+    public static ServiceHost? TryCreate(WordMcpService service, string pipeName, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(service);
+        ArgumentException.ThrowIfNullOrWhiteSpace(pipeName);
+
+        var mutex = new Mutex(initiallyOwned: true, $"WordMcp-host-{pipeName}", out var createdNew);
+        if (!createdNew)
+        {
+            mutex.Dispose();
+            return null;
+        }
+
+        return new ServiceHost(service, pipeName, mutex, logger);
+    }
+
+    /// <summary>
+    /// Accepts connections until the service asks to stop or the caller cancels.
+    /// </summary>
+    /// <param name="cancellationToken">Token that stops the host.</param>
+    /// <returns>A task that completes once the host has stopped listening.</returns>
+    public async Task RunAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(Volatile.Read(ref _disposed) == 1, this);
+
+        using var stopping = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var watching = WatchForStopAsync(stopping);
+        var connections = new List<Task>();
+
+        _logger?.LogInformation("Word session service listening on {PipeName}", PipeName);
+
+        try
+        {
+            while (!stopping.IsCancellationRequested)
+            {
+                var pipe = ServiceSecurity.CreateSecureServer(PipeName);
+
+                try
+                {
+                    await pipe.WaitForConnectionAsync(stopping.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    await pipe.DisposeAsync().ConfigureAwait(false);
+                    break;
+                }
+#pragma warning disable CA1031 // A failed accept must not end the host
+                catch (Exception ex)
+                {
+                    _logger?.LogWarning(ex, "Could not accept a connection on {PipeName}", PipeName);
+                    await pipe.DisposeAsync().ConfigureAwait(false);
+                    continue;
+                }
+#pragma warning restore CA1031
+
+                connections.Add(ServeAsync(pipe, stopping.Token));
+                connections.RemoveAll(t => t.IsCompleted);
+            }
+        }
+        finally
+        {
+            await stopping.CancelAsync().ConfigureAwait(false);
+            await watching.ConfigureAwait(false);
+
+            // Let in-flight requests finish so a client never sees a half-written response.
+            await Task.WhenAll(connections).ConfigureAwait(false);
+            _logger?.LogInformation("Word session service on {PipeName} stopped", PipeName);
+        }
+    }
+
+    /// <summary>
+    /// Releases the claim on the pipe name.
+    /// </summary>
+    public void Dispose()
+    {
+        if (Interlocked.CompareExchange(ref _disposed, 1, 0) != 0)
+        {
+            return;
+        }
+
+        if (_singleInstance is not null)
+        {
+            try
+            {
+                _singleInstance.ReleaseMutex();
+            }
+            catch (ApplicationException)
+            {
+                // Not owned any more; nothing to release.
+            }
+
+            _singleInstance.Dispose();
+        }
+    }
+
+    private async Task WatchForStopAsync(CancellationTokenSource stopping)
+    {
+        try
+        {
+            while (!stopping.IsCancellationRequested)
+            {
+                await Task.Delay(StopPollInterval, stopping.Token).ConfigureAwait(false);
+
+                if (_service.ShutdownRequested || _service.IsIdle)
+                {
+                    _logger?.LogInformation(
+                        "Stopping: {Reason}",
+                        _service.ShutdownRequested ? "a client requested shutdown" : "idle timeout elapsed");
+
+                    // Nudge the accept loop, which is otherwise parked on WaitForConnectionAsync.
+                    await using var nudge = ServiceSecurity.CreateClient(PipeName);
+                    await stopping.CancelAsync().ConfigureAwait(false);
+
+                    try
+                    {
+                        await nudge.ConnectAsync(500, CancellationToken.None).ConfigureAwait(false);
+                    }
+                    catch (TimeoutException)
+                    {
+                        // The loop was not waiting; it will notice the cancellation itself.
+                    }
+
+                    return;
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+    }
+
+    private async Task ServeAsync(System.IO.Pipes.NamedPipeServerStream pipe, CancellationToken cancellationToken)
+    {
+        await Task.Yield();
+
+        try
+        {
+            // No BOM and no auto-flush games: the framing is one line per message, so the writer
+            // flushes explicitly after each response.
+            using var reader = new StreamReader(pipe, new UTF8Encoding(false), false, 4096, leaveOpen: true);
+            await using var writer = new StreamWriter(pipe, new UTF8Encoding(false), 4096, leaveOpen: true);
+
+            while (!cancellationToken.IsCancellationRequested && pipe.IsConnected)
+            {
+                var line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+                if (line is null)
+                {
+                    break;
+                }
+
+                var response = await HandleAsync(line, cancellationToken).ConfigureAwait(false);
+
+                await writer.WriteLineAsync(ServiceProtocol.Serialize(response).AsMemory(), cancellationToken)
+                    .ConfigureAwait(false);
+                await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // The host is stopping.
+        }
+        catch (IOException)
+        {
+            // The client went away mid-conversation; nothing to report.
+        }
+#pragma warning disable CA1031 // One bad connection must not take the host down
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Connection on {PipeName} failed", PipeName);
+        }
+#pragma warning restore CA1031
+        finally
+        {
+            await pipe.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task<ServiceResponse> HandleAsync(string line, CancellationToken cancellationToken)
+    {
+        ServiceRequest? request;
+
+        try
+        {
+            request = ServiceProtocol.Deserialize<ServiceRequest>(line);
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            return ServiceResponse.Fail($"Malformed request: {ex.Message}", nameof(System.Text.Json.JsonException));
+        }
+
+        return request is null
+            ? ServiceResponse.Fail("Empty request.", nameof(ArgumentException))
+            : await _service.ProcessAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/WordMcp.Service/WordMcp.Service.csproj
+++ b/src/WordMcp.Service/WordMcp.Service.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0-windows</TargetFramework>
+    <OutputType>Exe</OutputType>
 
     <AssemblyName>WordMcp.Service</AssemblyName>
     <RootNamespace>WordMcp.Service</RootNamespace>
@@ -27,6 +28,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/WordMcp.Service.Tests/CommandLineTests.cs
+++ b/tests/WordMcp.Service.Tests/CommandLineTests.cs
@@ -1,0 +1,70 @@
+using Xunit;
+
+namespace WordMcp.Service.Tests;
+
+/// <summary>
+/// Command line parsing. Unknown input selects help rather than failing, so these pin that down
+/// alongside the ordinary modes.
+/// </summary>
+public class CommandLineTests
+{    [Fact]
+    public void NoArgumentsShowsHelp()
+        => Assert.Equal(RunMode.Help, CommandLine.Parse([]).Mode);
+
+    [Theory]
+    [InlineData("--daemon", RunMode.Daemon)]
+    [InlineData("--status", RunMode.Status)]
+    [InlineData("--stop", RunMode.Stop)]
+    [InlineData("--version", RunMode.Version)]
+    [InlineData("-v", RunMode.Version)]
+    [InlineData("--help", RunMode.Help)]
+    [InlineData("-h", RunMode.Help)]
+    public void AModeIsRecognised(string argument, RunMode expected)
+        => Assert.Equal(expected, CommandLine.Parse([argument]).Mode);
+
+    [Fact]
+    public void ModesAreCaseInsensitive()
+        => Assert.Equal(RunMode.Daemon, CommandLine.Parse(["--DAEMON"]).Mode);
+
+    [Fact]
+    public void AnUnknownArgumentFallsBackToHelp()
+        => Assert.Equal(RunMode.Help, CommandLine.Parse(["--frobnicate"]).Mode);
+
+    [Fact]
+    public void ThePipeDefaultsToThePerUserServicePipe()
+        => Assert.Equal(ServiceSecurity.GetServicePipeName(), CommandLine.Parse(["--daemon"]).PipeName);
+
+    [Fact]
+    public void ThePipeCanBeOverridden()
+        => Assert.Equal("custom-pipe", CommandLine.Parse(["--daemon", "--pipe", "custom-pipe"]).PipeName);
+
+    [Fact]
+    public void ADanglingPipeArgumentKeepsTheDefault()
+        => Assert.Equal(ServiceSecurity.GetServicePipeName(), CommandLine.Parse(["--daemon", "--pipe"]).PipeName);
+
+    [Fact]
+    public void TheIdleTimeoutIsReadInMinutes()
+        => Assert.Equal(TimeSpan.FromMinutes(7), CommandLine.Parse(["--daemon", "--idle-minutes", "7"]).IdleTimeout);
+
+    [Fact]
+    public void AnIdleTimeoutOfZeroIsAllowed()
+        => Assert.Equal(TimeSpan.Zero, CommandLine.Parse(["--daemon", "--idle-minutes", "0"]).IdleTimeout);
+
+    [Theory]
+    [InlineData("-5")]
+    [InlineData("soon")]
+    public void AnUnusableIdleTimeoutLeavesTheDefaultInPlace(string value)
+        => Assert.Null(CommandLine.Parse(["--daemon", "--idle-minutes", value]).IdleTimeout);
+
+    [Fact]
+    public void VerboseIsOffByDefault()
+        => Assert.False(CommandLine.Parse(["--daemon"]).Verbose);
+
+    [Fact]
+    public void VerboseCanBeTurnedOn()
+        => Assert.True(CommandLine.Parse(["--daemon", "--verbose"]).Verbose);
+
+    [Fact]
+    public void TheLastModeWins()
+        => Assert.Equal(RunMode.Stop, CommandLine.Parse(["--daemon", "--stop"]).Mode);
+}

--- a/tests/WordMcp.Service.Tests/ServiceHostTests.cs
+++ b/tests/WordMcp.Service.Tests/ServiceHostTests.cs
@@ -1,0 +1,378 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace WordMcp.Service.Tests;
+
+/// <summary>
+/// Host and client over a real named pipe. None of these need Word: every command used here is
+/// answered from the service's own state, which keeps the transport under test rather than COM.
+/// </summary>
+public sealed class ServiceHostTests : IDisposable
+{
+    private readonly CancellationTokenSource _cts = new(TimeSpan.FromMinutes(2));
+    private readonly List<Task> _running = [];
+    private readonly List<IDisposable> _disposables = [];
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+
+        try
+        {
+            Task.WaitAll([.. _running], TimeSpan.FromSeconds(30));
+        }
+        catch (AggregateException)
+        {
+            // Cancellation during teardown.
+        }
+
+        foreach (var disposable in _disposables)
+        {
+            disposable.Dispose();
+        }
+
+        _cts.Dispose();
+    }
+
+    private static string NewPipeName() => ServiceSecurity.GetPrivatePipeName($"test-{Guid.NewGuid():N}");
+
+    private ServiceHost StartHost(out WordMcpService service, TimeSpan? idleTimeout = null)
+    {
+        var pipeName = NewPipeName();
+        service = new WordMcpService(idleTimeout: idleTimeout ?? TimeSpan.FromMinutes(30));
+        _disposables.Add(service);
+
+        var host = ServiceHost.TryCreate(service, pipeName);
+        Assert.NotNull(host);
+        _disposables.Add(host);
+        _running.Add(host.RunAsync(_cts.Token));
+
+        return host;
+    }
+
+    private ServiceClient ClientFor(ServiceHost host)
+    {
+        var client = new ServiceClient(host.PipeName, new ServiceClientOptions
+        {
+            AutoStart = false,
+            ConnectTimeout = TimeSpan.FromSeconds(2),
+            RequestTimeout = TimeSpan.FromSeconds(30)
+        });
+
+        _disposables.Add(client);
+        return client;
+    }
+
+    private static async Task WaitUntilReadyAsync(ServiceClient client)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(20);
+
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (await client.PingAsync())
+            {
+                return;
+            }
+
+            await Task.Delay(50);
+        }
+
+        Assert.Fail($"No service answered on '{client.PipeName}' within 20 seconds.");
+    }
+
+    [Fact]
+    public async Task AHostedServiceAnswersAPing()
+    {
+        var host = StartHost(out _);
+        var client = ClientFor(host);
+
+        await WaitUntilReadyAsync(client);
+
+        Assert.True(await client.PingAsync());
+    }
+
+    [Fact]
+    public async Task ARequestIsAnsweredWithTheServicesResult()
+    {
+        var host = StartHost(out _);
+        var client = ClientFor(host);
+        await WaitUntilReadyAsync(client);
+
+        var response = await client.SendAsync(new ServiceRequest { Command = "session.list" });
+
+        Assert.True(response.Success, response.ErrorMessage);
+        Assert.Contains("\"count\":0", response.Result!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AFailedCommandComesBackAsAnUnsuccessfulResponse()
+    {
+        var host = StartHost(out _);
+        var client = ClientFor(host);
+        await WaitUntilReadyAsync(client);
+
+        var response = await client.SendAsync(new ServiceRequest { Command = "session.nonsense" });
+
+        Assert.False(response.Success);
+        Assert.Contains("session.nonsense", response.ErrorMessage!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ManyRequestsShareOneConnection()
+    {
+        var host = StartHost(out _);
+        var client = ClientFor(host);
+        await WaitUntilReadyAsync(client);
+
+        using var pipe = ServiceSecurity.CreateClient(host.PipeName);
+        await pipe.ConnectAsync(5000, _cts.Token);
+
+        var writer = new StreamWriter(pipe, new UTF8Encoding(false), 4096, leaveOpen: true) { AutoFlush = true };
+        using var reader = new StreamReader(pipe, new UTF8Encoding(false), false, 4096, leaveOpen: true);
+
+        for (var i = 0; i < 5; i++)
+        {
+            await writer.WriteLineAsync(
+                ServiceProtocol.Serialize(new ServiceRequest { Command = "service.ping" }).AsMemory(),
+                _cts.Token);
+
+            var line = await reader.ReadLineAsync(_cts.Token);
+            Assert.NotNull(line);
+            Assert.True(ServiceProtocol.Deserialize<ServiceResponse>(line)!.Success);
+        }
+    }
+
+    [Fact]
+    public async Task AMalformedLineIsRejectedWithoutDroppingTheConnection()
+    {
+        var host = StartHost(out _);
+        var client = ClientFor(host);
+        await WaitUntilReadyAsync(client);
+
+        using var pipe = ServiceSecurity.CreateClient(host.PipeName);
+        await pipe.ConnectAsync(5000, _cts.Token);
+
+        var writer = new StreamWriter(pipe, new UTF8Encoding(false), 4096, leaveOpen: true) { AutoFlush = true };
+        using var reader = new StreamReader(pipe, new UTF8Encoding(false), false, 4096, leaveOpen: true);
+
+        await writer.WriteLineAsync("{ this is not json".AsMemory(), _cts.Token);
+        var rejected = ServiceProtocol.Deserialize<ServiceResponse>((await reader.ReadLineAsync(_cts.Token))!)!;
+
+        Assert.False(rejected.Success);
+        Assert.Contains("Malformed", rejected.ErrorMessage!, StringComparison.Ordinal);
+
+        await writer.WriteLineAsync(
+            ServiceProtocol.Serialize(new ServiceRequest { Command = "service.ping" }).AsMemory(), _cts.Token);
+        var recovered = ServiceProtocol.Deserialize<ServiceResponse>((await reader.ReadLineAsync(_cts.Token))!)!;
+
+        Assert.True(recovered.Success);
+    }
+
+    [Fact]
+    public async Task TwoClientsAreServedAtTheSameTime()
+    {
+        var host = StartHost(out _);
+        var first = ClientFor(host);
+        var second = ClientFor(host);
+        await WaitUntilReadyAsync(first);
+
+        var responses = await Task.WhenAll(
+            first.SendAsync(new ServiceRequest { Command = "service.ping" }),
+            second.SendAsync(new ServiceRequest { Command = "session.list" }));
+
+        Assert.All(responses, r => Assert.True(r.Success, r.ErrorMessage));
+    }
+
+    [Fact]
+    public void ASecondHostCannotClaimTheSamePipe()
+    {
+        var host = StartHost(out var service);
+
+        using var duplicate = ServiceHost.TryCreate(service, host.PipeName);
+
+        Assert.Null(duplicate);
+    }
+
+    [Fact]
+    public void ThePipeNameIsFreedWhenTheHostIsDisposed()
+    {
+        var pipeName = NewPipeName();
+        using var service = new WordMcpService();
+
+        var first = ServiceHost.TryCreate(service, pipeName);
+        Assert.NotNull(first);
+        first.Dispose();
+
+        using var second = ServiceHost.TryCreate(service, pipeName);
+        Assert.NotNull(second);
+    }
+
+    [Fact]
+    public async Task AShutdownRequestStopsTheHost()
+    {
+        var pipeName = NewPipeName();
+        using var service = new WordMcpService();
+        using var host = ServiceHost.TryCreate(service, pipeName)!;
+        var running = host.RunAsync(_cts.Token);
+
+        using var client = new ServiceClient(pipeName, new ServiceClientOptions { AutoStart = false });
+        await WaitUntilReadyAsync(client);
+
+        Assert.True((await client.SendAsync(new ServiceRequest { Command = "service.shutdown" })).Success);
+
+        await running.WaitAsync(TimeSpan.FromSeconds(30));
+        Assert.True(running.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task AnIdleHostStopsOnItsOwn()
+    {
+        var pipeName = NewPipeName();
+        using var service = new WordMcpService(idleTimeout: TimeSpan.Zero);
+        using var host = ServiceHost.TryCreate(service, pipeName)!;
+
+        var running = host.RunAsync(_cts.Token);
+
+        await running.WaitAsync(TimeSpan.FromSeconds(30));
+        Assert.True(running.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task CancellingTheTokenStopsTheHost()
+    {
+        var pipeName = NewPipeName();
+        using var service = new WordMcpService();
+        using var host = ServiceHost.TryCreate(service, pipeName)!;
+        using var stopping = new CancellationTokenSource();
+
+        var running = host.RunAsync(stopping.Token);
+        using var client = new ServiceClient(pipeName, new ServiceClientOptions { AutoStart = false });
+        await WaitUntilReadyAsync(client);
+
+        await stopping.CancelAsync();
+
+        await running.WaitAsync(TimeSpan.FromSeconds(30));
+    }
+
+    [Fact]
+    public void TryCreate_RejectsMissingArguments()
+    {
+        using var service = new WordMcpService();
+
+        Assert.Throws<ArgumentNullException>(() => ServiceHost.TryCreate(null!, "pipe"));
+        Assert.Throws<ArgumentException>(() => ServiceHost.TryCreate(service, "  "));
+    }
+
+    [Fact]
+    public async Task AClientReportsAMissingServiceWhenAutoStartIsOff()
+    {
+        using var client = new ServiceClient(NewPipeName(), new ServiceClientOptions
+        {
+            AutoStart = false,
+            ConnectTimeout = TimeSpan.FromMilliseconds(500)
+        });
+
+        Assert.False(await client.PingAsync());
+
+        var response = await client.SendAsync(new ServiceRequest { Command = "service.ping" });
+
+        Assert.False(response.Success);
+        Assert.Contains("No Word session service", response.ErrorMessage!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task AClientReportsAFailedAutoStartWhenTheExecutableIsMissing()
+    {
+        using var client = new ServiceClient(NewPipeName(), new ServiceClientOptions
+        {
+            AutoStart = true,
+            ConnectTimeout = TimeSpan.FromMilliseconds(500),
+            ExecutablePath = Path.Combine(Path.GetTempPath(), $"missing-{Guid.NewGuid():N}.exe")
+        });
+
+        var response = await client.SendAsync(new ServiceRequest { Command = "service.ping" });
+
+        Assert.False(response.Success);
+        Assert.Contains("Could not start", response.ErrorMessage!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheDaemonExecutableShipsNextToItsClients()
+    {
+        var executable = ServiceClient.FindExecutable();
+
+        Assert.NotNull(executable);
+        Assert.True(File.Exists(executable));
+    }
+
+    [Fact]
+    public async Task AClientStartsTheDaemonItCannotReach()
+    {
+        var pipeName = NewPipeName();
+        using var client = new ServiceClient(pipeName, new ServiceClientOptions
+        {
+            AutoStart = true,
+            ConnectTimeout = TimeSpan.FromSeconds(1),
+            StartupTimeout = TimeSpan.FromSeconds(45),
+            IdleTimeout = TimeSpan.FromMinutes(1)
+        });
+
+        try
+        {
+            var response = await client.SendAsync(new ServiceRequest { Command = "service.ping" });
+
+            Assert.True(response.Success, response.ErrorMessage);
+
+            // The answer must come from another process, otherwise nothing was really started.
+            var payload = System.Text.Json.JsonDocument.Parse(response.Result!).RootElement;
+            Assert.NotEqual(Environment.ProcessId, payload.GetProperty("processId").GetInt32());
+            Assert.False(Process.GetProcessById(payload.GetProperty("processId").GetInt32()).HasExited);
+        }
+        finally
+        {
+            await client.SendAsync(new ServiceRequest { Command = "service.shutdown" });
+        }
+    }
+
+    [Fact]
+    public async Task ASecondCallReusesTheDaemonTheFirstOneStarted()
+    {
+        var pipeName = NewPipeName();
+        using var client = new ServiceClient(pipeName, new ServiceClientOptions
+        {
+            AutoStart = true,
+            ConnectTimeout = TimeSpan.FromSeconds(1),
+            StartupTimeout = TimeSpan.FromSeconds(45),
+            IdleTimeout = TimeSpan.FromMinutes(1)
+        });
+
+        try
+        {
+            var first = await client.SendAsync(new ServiceRequest { Command = "service.ping" });
+            var second = await client.SendAsync(new ServiceRequest { Command = "service.ping" });
+
+            Assert.True(first.Success, first.ErrorMessage);
+            Assert.True(second.Success, second.ErrorMessage);
+            Assert.Equal(first.Result, second.Result);
+        }
+        finally
+        {
+            await client.SendAsync(new ServiceRequest { Command = "service.shutdown" });
+        }
+    }
+
+    [Fact]
+    public void AClientRejectsABlankPipeName()
+        => Assert.Throws<ArgumentException>(() => new ServiceClient("  "));
+
+    [Fact]
+    public async Task ADisposedClientRefusesFurtherCalls()
+    {
+        var client = new ServiceClient(NewPipeName());
+        client.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(
+            () => client.SendAsync(new ServiceRequest { Command = "service.ping" }));
+    }
+}


### PR DESCRIPTION
Schliesst #44.

Der Service konnte Sessions bereits halten und Befehle beantworten -- aber nur fuer Code im eigenen Prozess. Dieser PR setzt ihn auf eine Named Pipe und macht ein Programm daraus.

## Was dazukommt

| Datei | Inhalt |
|---|---|
| `ServiceHost.cs` | Accept-Schleife, ein Task pro Verbindung, Watchdog fuer Shutdown und Idle |
| `ServiceClient.cs` | Senden, Ping, Auto-Start des Daemons |
| `Program.cs` | `--daemon`, `--status`, `--stop`, `--help`, `--version` |

`WordMcp.Service` ist jetzt `OutputType=Exe` und wird trotzdem weiterhin als Bibliothek referenziert -- .NET erlaubt das, und es erspart ein zweites Projekt fuer denselben Code.

## Entscheidungen

**Ein fehlender Service ist kein Fehler, sondern ein noch nicht gestarteter.** `SendAsync` verbindet sich zuerst; antwortet niemand und ist Auto-Start an, startet es den Daemon, wartet bis er lauscht, und versucht es erneut. Aufrufer muessen nie wissen, ob schon einer lief.

**Eine Verbindung pro Request.** Lokal kostet das Mikrosekunden und liefert Reconnect gratis: ein Daemon, der auf sein Idle-Timeout hin beendet wurde, wird vom naechsten Aufruf einfach neu gestartet -- ohne veralteten Verbindungszustand, ueber den man nachdenken muesste.

**Single-Instance ueber einen benannten Mutex, nicht ueber die Pipe.** Windows erlaubt mehrere Server auf demselben Pipe-Namen. Ohne den Mutex wuerden zwei Daemons beide scheinbar starten und jeder Client saehe die Haelfte der Sessions. `WordMcp-host-{pipeName}` klaert das, bevor die Pipe ueberhaupt entsteht.

**Der Nudge.** `WaitForConnectionAsync` laesst sich unter Windows von keinem CancellationToken unterbrechen. Der Watchdog, der Shutdown oder Idle bemerkt, weckt die Accept-Schleife deshalb mit einer Wegwerf-Verbindung.

**Unbekannte Argumente zeigen Hilfe, statt zu scheitern.** Ein Daemon, der sich weigert sich zu erklaeren, ist schlimmer als einer, der zu viel erklaert.

## Tests

39 neue Tests, alle ueber eine echte Pipe -- **kein Word noetig**, weil jeder verwendete Befehl aus dem Zustand des Service selbst beantwortet wird. Damit steht der Transport unter Test und nicht COM.

Zwei Tests starten die echte `WordMcp.Service.exe`: einer prueft, dass die Antwort aus einem *anderen* Prozess kommt (sonst waere nichts wirklich gestartet worden), der andere, dass ein zweiter Aufruf denselben Daemon wiederverwendet.

Ebenfalls festgenagelt: eine kaputte Zeile wird mit einer Fehlerantwort quittiert, ohne die Verbindung zu verlieren; ein zweiter Host auf derselben Pipe bekommt `null`; ein Host mit Idle-Timeout `Zero` beendet sich von selbst.

`dotnet test` (ohne Word): **95 Tests gruen in 15 s.**

Von Hand gegengeprueft: `--daemon` starten, `--status` liest Prozess-Id, Sessionzahl und Idle-Timeout, `--stop` beendet ihn.

## Doku

`docs/architecture.md` bekommt den Abschnitt *The daemon*, `README.md` unter *Concepts* einen kurzen Abschnitt *The session service*.
