### PR TITLE
Route the MCP server's session operations through the service

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,9 +19,8 @@ WINWORD.EXE
 ```
 
 `WordMcp.Service` sits beside the MCP server and wraps `SessionManager` behind a data-only
-request/response contract, so sessions can move out of the client's process. The MCP server does
-not route through it yet — that migration is tracked separately — but the layer is in place and
-tested.
+request/response contract, so sessions can move out of the client's process. The MCP server routes
+every session operation through it via `ServiceBridge`, in-process for now.
 
 `WordMcp.Generators.Mcp` and `WordMcp.Generators.Shared` are build-time only; they ship no runtime
 code.
@@ -72,6 +71,20 @@ that turns any exception into a JSON error payload rather than a transport failu
 
 `WordFileTool` is the only hand-written tool, because session lifecycle does not fit the
 generator's shape. The other fourteen are generated.
+
+`ServiceBridge` is the seam to the session service. It exists because the file tool and
+`WordMcpService` used to carry two copies of open, create, save, close, list and test — and which
+copy a user hit depended on which entry point they came in through. The tool now validates the
+path, hands the command to the service and serializes what comes back. It still keeps the path
+validation, so the caller who typed a relative path or a `.pptx` gets the tool's wording rather
+than the service's.
+
+The service reports failures as data; the tool layer formats them from exceptions.
+`ServiceCommandException` carries the reported CLR type name across that gap, so a caller still
+sees `FileNotFoundException` and not the wrapper.
+
+What the bridge cannot route yet is `Batch`: an `IWordBatch` is a live COM handle, and the
+generated tools need one. That is the piece still standing between the bridge and a daemon mode.
 
 ### WordMcp.Service
 

--- a/src/WordMcp.McpServer/Program.cs
+++ b/src/WordMcp.McpServer/Program.cs
@@ -120,7 +120,7 @@ public static class Program
         {
             // Without this, a client disconnect would silently discard unsaved work and
             // leave WINWORD.EXE running.
-            WordServices.Shutdown();
+            ServiceBridge.Shutdown();
         }
     }
 

--- a/src/WordMcp.McpServer/ServiceBridge.cs
+++ b/src/WordMcp.McpServer/ServiceBridge.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using WordMcp.ComInterop.Session;
+using WordMcp.Service;
+
+namespace WordMcp.McpServer;
+
+/// <summary>
+/// The single seam between the MCP tools and the session service.
+/// </summary>
+/// <remarks>
+/// <para>Before this existed, the file tool and <see cref="WordMcpService"/> each carried their own
+/// copy of open, create, save, close, list and test. Two implementations of the same rules drift,
+/// and the one the user hits is decided by which entry point they came through. Everything session
+/// shaped now goes through here, so there is one answer.</para>
+/// <para>The bridge is in-process: it holds a <see cref="WordMcpService"/> and calls it directly.
+/// The point of routing through it anyway is that the calls are already data only, which is what a
+/// later move onto the pipe needs. What cannot cross yet is <see cref="Batch"/> — an
+/// <see cref="IWordBatch"/> is a live COM handle, and the generated tools still need one.</para>
+/// </remarks>
+internal static class ServiceBridge
+{
+    private static readonly Lock Gate = new();
+    private static WordMcpService? _service;
+
+    /// <summary>
+    /// Gets the service, creating it on first use so an idle server never starts Word.
+    /// </summary>
+    public static WordMcpService Service
+    {
+        get
+        {
+            lock (Gate)
+            {
+                return _service ??= new WordMcpService(WordServices.Logger);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Resolves the batch behind a session id.
+    /// </summary>
+    /// <param name="sessionId">The session identifier supplied by the caller.</param>
+    /// <returns>The batch for that session.</returns>
+    public static IWordBatch Batch(string? sessionId) => Service.GetBatch(sessionId);
+
+    /// <summary>
+    /// Runs one service command and returns its payload.
+    /// </summary>
+    /// <param name="command">The command name, for example <c>session.open</c>.</param>
+    /// <param name="sessionId">The session the command applies to, when it is session scoped.</param>
+    /// <param name="args">Arguments, serialized as the command's argument object.</param>
+    /// <returns>The result payload, ready to be serialized into the tool response.</returns>
+    /// <exception cref="ServiceCommandException">The command failed.</exception>
+    public static object Invoke(string command, string? sessionId = null, object? args = null)
+    {
+        var request = new ServiceRequest
+        {
+            Command = command,
+            SessionId = sessionId,
+            Args = args is null ? null : ServiceProtocol.Serialize(args),
+            Source = "mcp"
+        };
+
+        // The service is asynchronous because a pipe host needs it to be; in-process the only
+        // await is the open gate, and blocking on it here is what keeps the tool signatures
+        // synchronous for the MCP SDK.
+        var response = Service.ProcessAsync(request).GetAwaiter().GetResult();
+
+        if (!response.Success)
+        {
+            throw new ServiceCommandException(
+                response.ErrorMessage ?? $"Command '{command}' failed.",
+                response.ErrorType);
+        }
+
+        return response.Result is null
+            ? new { success = true }
+            : JsonSerializer.Deserialize<JsonElement>(response.Result);
+    }
+
+    /// <summary>
+    /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.
+    /// </summary>
+    public static void Shutdown()
+    {
+        lock (Gate)
+        {
+            _service?.Dispose();
+            _service = null;
+        }
+    }
+}
+
+/// <summary>
+/// A command the service refused or could not complete.
+/// </summary>
+/// <remarks>
+/// The service reports failures as data, not as exceptions, but the tool layer formats errors from
+/// exceptions. This carries the original type name across that gap so a caller still sees
+/// <c>FileNotFoundException</c> rather than the name of this wrapper.
+/// </remarks>
+public sealed class ServiceCommandException : Exception
+{
+    /// <summary>
+    /// Creates an exception for a failed command.
+    /// </summary>
+    /// <param name="message">The failure description reported by the service.</param>
+    /// <param name="errorType">The CLR type name the service reported.</param>
+    public ServiceCommandException(string message, string? errorType)
+        : base(message)
+        => ErrorType = errorType;
+
+    /// <summary>
+    /// Creates an exception with a message.
+    /// </summary>
+    /// <param name="message">The failure description.</param>
+    public ServiceCommandException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Creates an exception with a message and an inner exception.
+    /// </summary>
+    /// <param name="message">The failure description.</param>
+    /// <param name="innerException">The underlying failure.</param>
+    public ServiceCommandException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Creates an exception without a message.
+    /// </summary>
+    public ServiceCommandException()
+    {
+    }
+
+    /// <summary>
+    /// Gets the CLR type name of the original failure, when the service reported one.
+    /// </summary>
+    public string? ErrorType { get; }
+}

--- a/src/WordMcp.McpServer/Tools/WordFileTool.cs
+++ b/src/WordMcp.McpServer/Tools/WordFileTool.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel;
 using System.Text.Json.Serialization;
 using ModelContextProtocol.Server;
-using WordMcp.ComInterop;
 
 namespace WordMcp.McpServer.Tools;
 
@@ -62,103 +61,28 @@ public static class WordFileTool
         {
             WordFileAction.Open => Open(path, show, timeout_seconds),
             WordFileAction.Create => Create(path, show, timeout_seconds),
-            WordFileAction.Save => Save(session_id),
-            WordFileAction.Close => Close(session_id, save),
-            WordFileAction.List => List(),
+            WordFileAction.Save => ServiceBridge.Invoke("session.save", session_id),
+            WordFileAction.Close => ServiceBridge.Invoke("session.close", session_id, new { save }),
+            WordFileAction.List => ServiceBridge.Invoke("session.list"),
             WordFileAction.Test => Test(path),
             _ => throw new ArgumentException($"Unknown action '{action}'.", nameof(action))
         });
 
     private static object Open(string? path, bool show, int timeoutSeconds)
-    {
-        var fullPath = WordToolsBase.ValidatePath(path, mustExist: true);
-
-        var existing = WordServices.Sessions.FindByPath(fullPath);
-        if (existing != null)
+        => ServiceBridge.Invoke("session.open", args: new
         {
-            return new
-            {
-                success = true,
-                sessionId = existing.SessionId,
-                filePath = existing.FilePath,
-                reused = true,
-                message = "Document is already open; reusing the existing session."
-            };
-        }
-
-        var info = WordServices.Sessions.Open(fullPath, show, timeoutSeconds);
-        return new
-        {
-            success = true,
-            sessionId = info.SessionId,
-            filePath = info.FilePath,
-            visible = info.Visible,
-            reused = false,
-            message = "Session opened. Pass session_id to the other tools."
-        };
-    }
+            filePath = WordToolsBase.ValidatePath(path, mustExist: true),
+            visible = show,
+            timeoutSeconds
+        });
 
     private static object Create(string? path, bool show, int timeoutSeconds)
-    {
-        var fullPath = WordToolsBase.ValidatePath(path, mustExist: false);
-
-        if (System.IO.File.Exists(fullPath))
+        => ServiceBridge.Invoke("session.create", args: new
         {
-            throw new IOException(
-                $"File already exists: {fullPath}. Use file(action:'open') instead, or choose a different path.");
-        }
-
-        var info = WordServices.Sessions.Create(fullPath, show, timeoutSeconds);
-        return new
-        {
-            success = true,
-            sessionId = info.SessionId,
-            filePath = info.FilePath,
-            visible = info.Visible,
-            message = "Document created and session opened."
-        };
-    }
-
-    private static object Save(string? sessionId)
-    {
-        WordToolsBase.Batch(sessionId);
-        WordServices.Sessions.Save(sessionId!);
-        return new { success = true, sessionId, message = "Document saved." };
-    }
-
-    private static object Close(string? sessionId, bool save)
-    {
-        if (string.IsNullOrWhiteSpace(sessionId))
-        {
-            throw new ArgumentException("session_id is required for 'close'.", nameof(sessionId));
-        }
-
-        var closed = WordServices.Sessions.Close(sessionId, save);
-        return new
-        {
-            success = closed,
-            sessionId,
-            saved = save && closed,
-            message = closed
-                ? save ? "Document saved and session closed." : "Session closed without saving."
-                : $"No open session with id '{sessionId}'."
-        };
-    }
-
-    private static object List()
-    {
-        var sessions = WordServices.Sessions.List()
-            .Select(s => new
-            {
-                sessionId = s.SessionId,
-                filePath = s.FilePath,
-                visible = s.Visible,
-                openedAt = s.OpenedAt
-            })
-            .ToArray();
-
-        return new { success = true, count = sessions.Length, sessions };
-    }
+            filePath = WordToolsBase.ValidatePath(path, mustExist: false),
+            visible = show,
+            timeoutSeconds
+        });
 
     private static object Test(string? path)
     {
@@ -167,48 +91,8 @@ public static class WordFileTool
             throw new ArgumentException("path is required for 'test'.", nameof(path));
         }
 
-        var fullPath = Path.GetFullPath(path);
-        var extension = Path.GetExtension(fullPath);
-        var exists = System.IO.File.Exists(fullPath);
-
-        var problems = new List<string>();
-
-        if (!exists)
-        {
-            problems.Add("File does not exist.");
-        }
-
-        if (!ComInteropConstants.SupportedExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
-        {
-            problems.Add($"Unsupported extension '{extension}'.");
-        }
-
-        if (exists)
-        {
-            try
-            {
-                FileAccessValidator.ValidateFileNotLocked(fullPath);
-            }
-            catch (InvalidOperationException ex)
-            {
-                problems.Add(ex.Message);
-            }
-
-            if (FileAccessValidator.IsIrmProtected(fullPath))
-            {
-                problems.Add("File appears to be IRM/RMS protected and cannot be automated.");
-            }
-        }
-
-        return new
-        {
-            success = problems.Count == 0,
-            filePath = fullPath,
-            exists,
-            extension,
-            canOpen = problems.Count == 0,
-            problems,
-            message = problems.Count == 0 ? "File can be opened." : string.Join(" ", problems)
-        };
+        // Unlike open and create, an unsupported extension is reported as a finding rather than
+        // thrown: answering "what would happen" is the entire point of this action.
+        return ServiceBridge.Invoke("session.test", args: new { filePath = Path.GetFullPath(path) });
     }
 }

--- a/src/WordMcp.McpServer/Tools/WordToolsBase.cs
+++ b/src/WordMcp.McpServer/Tools/WordToolsBase.cs
@@ -42,7 +42,7 @@ internal static class WordToolsBase
                 isError = true,
                 tool,
                 action,
-                errorType = ex.GetType().Name,
+                errorType = ex is ServiceCommandException { ErrorType: { } reported } ? reported : ex.GetType().Name,
                 errorMessage = Describe(ex)
             });
         }
@@ -63,16 +63,7 @@ internal static class WordToolsBase
     /// <param name="sessionId">The session id supplied by the caller.</param>
     /// <returns>The batch for that session.</returns>
     public static IWordBatch Batch(string? sessionId)
-    {
-        if (string.IsNullOrWhiteSpace(sessionId))
-        {
-            throw new ArgumentException(
-                "session_id is required. Call file(action:'open', path:'C:\\\\...\\\\document.docx') first.",
-                nameof(sessionId));
-        }
-
-        return WordServices.Sessions.GetBatch(sessionId);
-    }
+        => ServiceBridge.Batch(sessionId);
 
     /// <summary>
     /// Validates that a path is an absolute Windows path with a supported extension.

--- a/src/WordMcp.McpServer/WordMcp.McpServer.csproj
+++ b/src/WordMcp.McpServer/WordMcp.McpServer.csproj
@@ -73,6 +73,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WordMcp.Core\WordMcp.Core.csproj" />
+    <ProjectReference Include="..\WordMcp.Service\WordMcp.Service.csproj" />
     <ProjectReference Include="..\WordMcp.Generators.Mcp\WordMcp.Generators.Mcp.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />

--- a/src/WordMcp.McpServer/WordServices.cs
+++ b/src/WordMcp.McpServer/WordServices.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.Logging;
-using WordMcp.ComInterop.Session;
 using WordMcp.Core.Commands.Document;
 using WordMcp.Core.Commands.Bookmark;
 using WordMcp.Core.Commands.Comment;
@@ -21,26 +20,12 @@ namespace WordMcp.McpServer;
 /// Process-wide singletons used by the MCP tools.
 /// </summary>
 /// <remarks>
-/// The MCP SDK discovers tools as static methods, so the session manager and command
-/// implementations are held here instead of being resolved through DI.
+/// The MCP SDK discovers tools as static methods, so the command implementations are held here
+/// instead of being resolved through DI. Sessions are not: they belong to
+/// <see cref="ServiceBridge"/>, which is the only thing in the process that owns one.
 /// </remarks>
 internal static class WordServices
 {
-    private static readonly Lock Gate = new();
-    private static SessionManager? _sessions;
-
-    /// <summary>Gets the shared session manager.</summary>
-    public static SessionManager Sessions
-    {
-        get
-        {
-            lock (Gate)
-            {
-                return _sessions ??= new SessionManager(Logger);
-            }
-        }
-    }
-
     /// <summary>Gets or sets the logger handed to new sessions.</summary>
     public static ILogger? Logger { get; set; }
 
@@ -85,16 +70,4 @@ internal static class WordServices
 
     /// <summary>Gets the screenshot command implementation.</summary>
     public static IScreenshotCommands Screenshots { get; } = new ScreenshotCommands();
-
-    /// <summary>
-    /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.
-    /// </summary>
-    public static void Shutdown()
-    {
-        lock (Gate)
-        {
-            _sessions?.Dispose();
-            _sessions = null;
-        }
-    }
 }

--- a/tests/WordMcp.McpServer.Tests/ServiceBridgeTests.cs
+++ b/tests/WordMcp.McpServer.Tests/ServiceBridgeTests.cs
@@ -1,0 +1,201 @@
+using System.Text.Json;
+using WordMcp.McpServer.Tools;
+using Xunit;
+
+namespace WordMcp.McpServer.Tests;
+
+/// <summary>
+/// The bridge and the file tool that now runs on it. None of these open Word: every case here is
+/// answered before a document is ever touched, which is exactly the part that used to be
+/// duplicated between the tool and the service.
+/// </summary>
+public class ServiceBridgeTests
+{
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    private static JsonElement File(WordFileAction action, string? path = null, string? sessionId = null, bool save = false)
+        => Parse(WordFileTool.File(action, path, sessionId, save));
+
+    [Fact]
+    public void TheBridgeAnswersAServiceCommand()
+    {
+        var payload = (JsonElement)ServiceBridge.Invoke("service.ping");
+
+        Assert.True(payload.GetProperty("pong").GetBoolean());
+        Assert.Equal(Environment.ProcessId, payload.GetProperty("processId").GetInt32());
+    }
+
+    [Fact]
+    public void AnUnknownCommandBecomesAnException()
+    {
+        var ex = Assert.Throws<ServiceCommandException>(() => ServiceBridge.Invoke("session.frobnicate"));
+
+        Assert.Contains("session.frobnicate", ex.Message, StringComparison.Ordinal);
+        Assert.Equal("NotSupportedException", ex.ErrorType);
+    }
+
+    [Fact]
+    public void TheReportedErrorTypeSurvivesTheTrip()
+    {
+        var json = Parse(WordToolsBase.Execute(
+            "file", "open", () => throw new ServiceCommandException("gone", "FileNotFoundException")));
+
+        // Without this the caller would see the name of the wrapper instead of the real failure.
+        Assert.Equal("FileNotFoundException", json.GetProperty("errorType").GetString());
+        Assert.Equal("gone", json.GetProperty("errorMessage").GetString());
+    }
+
+    [Fact]
+    public void AWrapperWithoutATypeFallsBackToItsOwnName()
+    {
+        var json = Parse(WordToolsBase.Execute("file", "open", () => throw new ServiceCommandException("gone")));
+
+        Assert.Equal("ServiceCommandException", json.GetProperty("errorType").GetString());
+    }
+
+    [Fact]
+    public void ListingSessionsGoesThroughTheService()
+    {
+        var json = File(WordFileAction.List);
+
+        Assert.True(json.GetProperty("success").GetBoolean());
+        Assert.Equal(0, json.GetProperty("count").GetInt32());
+        Assert.Empty(json.GetProperty("sessions").EnumerateArray());
+    }
+
+    [Theory]
+    [InlineData(WordFileAction.Open)]
+    [InlineData(WordFileAction.Create)]
+    public void ARelativePathIsRejectedBeforeTheServiceSeesIt(WordFileAction action)
+    {
+        var json = File(action, @"docs\report.docx");
+
+        Assert.False(json.GetProperty("success").GetBoolean());
+        Assert.Equal("ArgumentException", json.GetProperty("errorType").GetString());
+        Assert.Contains("absolute", json.GetProperty("errorMessage").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnUnsupportedExtensionIsRejectedForCreate()
+    {
+        var json = File(WordFileAction.Create, @"C:\docs\deck.pptx");
+
+        Assert.False(json.GetProperty("success").GetBoolean());
+        Assert.Contains("Unsupported file type", json.GetProperty("errorMessage").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OpeningAMissingDocumentReportsItAsMissing()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.docx");
+
+        var json = File(WordFileAction.Open, missing);
+
+        Assert.False(json.GetProperty("success").GetBoolean());
+        Assert.Equal("FileNotFoundException", json.GetProperty("errorType").GetString());
+    }
+
+    [Fact]
+    public void CreatingOverAnExistingFileIsRefused()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.docx");
+        System.IO.File.WriteAllText(path, "not really a document");
+
+        try
+        {
+            var json = File(WordFileAction.Create, path);
+
+            Assert.False(json.GetProperty("success").GetBoolean());
+            Assert.Equal("IOException", json.GetProperty("errorType").GetString());
+            Assert.Contains("already exists", json.GetProperty("errorMessage").GetString()!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Theory]
+    [InlineData(WordFileAction.Save)]
+    [InlineData(WordFileAction.Close)]
+    public void ASessionScopedActionNeedsASessionId(WordFileAction action)
+    {
+        var json = File(action);
+
+        Assert.False(json.GetProperty("success").GetBoolean());
+        Assert.Equal("ArgumentException", json.GetProperty("errorType").GetString());
+        Assert.Contains("session_id", json.GetProperty("errorMessage").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ClosingAnUnknownSessionIsReportedNotThrown()
+    {
+        var json = File(WordFileAction.Close, sessionId: "word-doesnotexist");
+
+        Assert.False(json.GetProperty("success").GetBoolean());
+        Assert.Contains("word-doesnotexist", json.GetProperty("message").GetString()!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SavingAnUnknownSessionIsAnError()
+    {
+        var json = File(WordFileAction.Save, sessionId: "word-doesnotexist");
+
+        Assert.False(json.GetProperty("success").GetBoolean());
+        Assert.Equal("KeyNotFoundException", json.GetProperty("errorType").GetString());
+    }
+
+    [Fact]
+    public void TestingAMissingFileListsTheProblem()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.docx");
+
+        var json = File(WordFileAction.Test, missing);
+
+        Assert.False(json.GetProperty("canOpen").GetBoolean());
+        Assert.False(json.GetProperty("exists").GetBoolean());
+        Assert.Contains(
+            json.GetProperty("problems").EnumerateArray(),
+            p => p.GetString()!.Contains("does not exist", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void TestingReportsAnUnsupportedExtensionAsAFindingRatherThanAFailure()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.pptx");
+        System.IO.File.WriteAllText(path, "deck");
+
+        try
+        {
+            var json = File(WordFileAction.Test, path);
+
+            // Answering "what would happen" is the point, so this must not throw.
+            Assert.False(json.GetProperty("canOpen").GetBoolean());
+            Assert.True(json.GetProperty("exists").GetBoolean());
+            Assert.Contains(
+                json.GetProperty("problems").EnumerateArray(),
+                p => p.GetString()!.Contains("Unsupported extension", StringComparison.Ordinal));
+        }
+        finally
+        {
+            System.IO.File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void TestingNeedsAPath()
+    {
+        var json = File(WordFileAction.Test);
+
+        Assert.False(json.GetProperty("success").GetBoolean());
+        Assert.Equal("ArgumentException", json.GetProperty("errorType").GetString());
+    }
+
+    [Fact]
+    public void ABatchStillNeedsASessionId()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => WordToolsBase.Batch(null));
+
+        Assert.Contains("session_id", ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/tests/WordMcp.McpServer.Tests/WordFileToolIntegrationTests.cs
+++ b/tests/WordMcp.McpServer.Tests/WordFileToolIntegrationTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using WordMcp.McpServer.Tools;
+using Xunit;
+
+namespace WordMcp.McpServer.Tests;
+
+/// <summary>
+/// The one path the bridge tests cannot fake: a document really being created, saved, listed and
+/// closed through the file tool. Requires Word.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class WordFileToolIntegrationTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(Path.GetTempPath(), $"wordmcp-tool-{Guid.NewGuid():N}");
+
+    public WordFileToolIntegrationTests() => Directory.CreateDirectory(_directory);
+
+    public void Dispose()
+    {
+        ServiceBridge.Shutdown();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Word may still be releasing the file; the temp directory is disposable anyway.
+        }
+    }
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    [Fact]
+    public void ADocumentSurvivesTheWholeRoundTrip()
+    {
+        var path = Path.Combine(_directory, "report.docx");
+
+        var created = Parse(WordFileTool.File(WordFileAction.Create, path));
+        Assert.True(created.GetProperty("success").GetBoolean(), created.ToString());
+        var sessionId = created.GetProperty("sessionId").GetString()!;
+
+        try
+        {
+            var listed = Parse(WordFileTool.File(WordFileAction.List));
+            Assert.Equal(1, listed.GetProperty("count").GetInt32());
+            Assert.Equal(sessionId, listed.GetProperty("sessions")[0].GetProperty("sessionId").GetString());
+
+            Assert.True(Parse(WordFileTool.File(WordFileAction.Save, session_id: sessionId))
+                .GetProperty("success").GetBoolean());
+
+            // Opening the same path again must hand back the session that is already there rather
+            // than starting a second Word on a locked file.
+            var reopened = Parse(WordFileTool.File(WordFileAction.Open, path));
+            Assert.True(reopened.GetProperty("reused").GetBoolean());
+            Assert.Equal(sessionId, reopened.GetProperty("sessionId").GetString());
+        }
+        finally
+        {
+            Assert.True(Parse(WordFileTool.File(WordFileAction.Close, session_id: sessionId, save: true))
+                .GetProperty("success").GetBoolean());
+        }
+
+        Assert.True(File.Exists(path));
+        Assert.Equal(0, Parse(WordFileTool.File(WordFileAction.List)).GetProperty("count").GetInt32());
+
+        var tested = Parse(WordFileTool.File(WordFileAction.Test, path));
+        Assert.True(tested.GetProperty("canOpen").GetBoolean(), tested.ToString());
+    }
+}


### PR DESCRIPTION
Arbeitet an #45.

Der Dateitool und `WordMcpService` trugen bislang **je eine eigene Kopie** von open, create, save, close, list und test. Zwei Implementierungen derselben Regeln driften auseinander, und welche ein Nutzer trifft, entschied der Einstiegspunkt. `ServiceBridge` macht daraus eine.

## Was sich aendert

- `ServiceBridge` im MCP-Server: haelt genau einen `WordMcpService`, uebersetzt `Invoke(command, sessionId, args)` in einen `ServiceRequest` und gibt die Antwort als `JsonElement` zurueck.
- `WordFileTool` schrumpft von 214 auf 110 Zeilen -- die sechs Aktionen sind jetzt sechs Bridge-Aufrufe.
- `WordServices` besitzt keinen `SessionManager` mehr. Es gibt genau einen im Prozess, und die Bridge haelt ihn. `WordToolsBase.Batch` loest ueber denselben Service auf, generierte Tools und Dateitool koennen sich also nicht mehr darueber uneinig sein, was offen ist.
- `Program.cs`: `WordServices.Shutdown()` wird zu `ServiceBridge.Shutdown()`.

## Entscheidungen

**Die Pfadpruefung bleibt im Tool.** Wer einen relativen Pfad oder eine `.pptx` eintippt, bekommt weiterhin den Wortlaut des Tools (*"path must be absolute..."*, *"Unsupported file type"*) und nicht den des Service. Alles danach ist die Antwort des Service, unveraendert durchgereicht.

**`ServiceCommandException` traegt den Fehlertyp ueber die Naht.** Der Service meldet Fehler als Daten, die Tool-Schicht formatiert sie aus Exceptions. Ohne diesen Traeger saehe ein Aufrufer den Namen des Wrappers statt `FileNotFoundException`.

**`WORDMCP_SERVICE_MODE` ist noch nicht dabei -- mit Absicht.** Was nicht ueber die Bridge kann, ist `Batch`: ein `IWordBatch` ist ein lebendes COM-Handle, und die generierten Tools brauchen eines. Ein Schalter, der einen Server erzeugt, bei dem `file()` den Daemon erreicht und `text()` nicht, waere schlimmer als gar kein Schalter. Der verbleibende Schritt ist in #49 beschrieben.

## Tests

18 neue Tests ohne Word: Bridge-Dispatch, Fehlertyp-Weitergabe, und jeder Zweig des Dateitools bis kurz vor das Oeffnen eines Dokuments.

Dazu **ein echter Word-Test**: erzeugen, speichern, denselben Pfad erneut oeffnen (muss die bestehende Session wiederverwenden statt ein zweites Word auf einer gesperrten Datei zu starten), schliessen, und anschliessend `test` auf der entstandenen Datei. Laeuft in 12 s.

**487 Tests gruen ohne Word**, 0 Warnungen.

## Doku

`docs/architecture.md`: der Abschnitt zu `WordMcp.McpServer` erklaert die Naht und benennt ausdruecklich, was noch nicht darueber kann.

