### PR TITLE
feat: run the generated tools across the process boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ Starting it by hand is rarely necessary — a client configured to use it starts
 pipe it listens on embeds your SID and is ACL'd to it, so sessions are never shared between
 accounts. It exits on its own once no session has been open for the idle timeout.
 
+To use it, set `WORDMCP_SERVICE_MODE=daemon` for the MCP server. Every tool call then travels to
+the daemon instead of running in the server's own process. Without it the server keeps sessions to
+itself, which is what a single client wants: no second process and no startup wait.
+
 ---
 
 ## Tools

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,26 +65,27 @@ through.
 ### WordMcp.McpServer
 
 The host: stdio transport, DI, logging to stderr from `Warning` upwards (stdout carries the
-protocol, and MCP clients surface stderr as an error). `WordServices` exposes one static property
-per command interface, and `WordToolsBase` provides the shared serialization and the `try`/`catch`
-that turns any exception into a JSON error payload rather than a transport failure.
+protocol, and MCP clients surface stderr as an error). `WordToolsBase` provides the shared
+serialization and the `try`/`catch` that turns any exception into a JSON error payload rather than
+a transport failure.
 
 `WordFileTool` is the only hand-written tool, because session lifecycle does not fit the
 generator's shape. The other fourteen are generated.
 
-`ServiceBridge` is the seam to the session service. It exists because the file tool and
-`WordMcpService` used to carry two copies of open, create, save, close, list and test — and which
-copy a user hit depended on which entry point they came in through. The tool now validates the
-path, hands the command to the service and serializes what comes back. It still keeps the path
-validation, so the caller who typed a relative path or a `.pptx` gets the tool's wording rather
-than the service's.
+`ServiceBridge` is the seam to the session service, and everything crossing it is data. It exists
+because the file tool and `WordMcpService` used to carry two copies of open, create, save, close,
+list and test — and which copy a user hit depended on which entry point they came in through. A
+tool now validates what only it can validate, hands the command to the service and serializes what
+comes back. Path validation stays in the tool, so the caller who typed a relative path or a `.pptx`
+gets the tool's wording rather than the service's.
 
 The service reports failures as data; the tool layer formats them from exceptions.
 `ServiceCommandException` carries the reported CLR type name across that gap, so a caller still
 sees `FileNotFoundException` and not the wrapper.
 
-What the bridge cannot route yet is `Batch`: an `IWordBatch` is a live COM handle, and the
-generated tools need one. That is the piece still standing between the bridge and a daemon mode.
+Nothing in this project holds a COM object any more — not even indirectly. That is what makes
+`WORDMCP_SERVICE_MODE=daemon` a working switch rather than a promise: the same tool call runs
+in-process or travels down a pipe to another process, and no tool can tell which.
 
 ### WordMcp.Service
 
@@ -135,20 +136,43 @@ against a running one. `ServiceClient` is the other side, and starting it is the
 The accept loop parks in `WaitForConnectionAsync`, which no cancellation token can interrupt on
 Windows, so the watchdog that notices shutdown or idleness wakes it with a throwaway connection.
 
+Set `WORDMCP_SERVICE_MODE=daemon` to make the MCP server route every command through that pipe
+instead of running the service in its own process. In-process stays the default because it is what
+a single client wants: no second process, no pipe, no startup wait. The daemon earns its keep only
+when several clients have to see the same open document.
+
+One thing the daemon uncovered that no in-process run could: Word is driven through `dynamic`, and
+the runtime binder needs `office.dll` to bind a member — a file every build copies next to the
+executable but no package declares as a runtime dependency. A test host probes its own directory
+and hides this; a plain executable does not, and the daemon could not open a single document until
+`ComAssemblyResolver` taught it to look. It resolves only the Office interop assemblies, from the
+application directory, and is installed by `WordBatch` itself so no host has to remember it.
+
 ## The generated tool layer
 
-A source generator reads the command interfaces and emits one MCP tool class per
-`[ServiceCategory]`. For each tool it produces a method with an `action` parameter, the union of
-all parameters of that tool's actions (each nullable, since a given action uses only some), a
-switch over the action names, and the `Execute` wrapper.
+A source generator reads the command interfaces and emits **both halves of the process boundary**
+from the same description, which is the only way they cannot drift apart:
 
-The generator resolves the interface type to the `WordServices` property that provides it. **A new
-command interface without a matching property on `WordServices` produces nothing** — no error, no
-tool.
+- In `WordMcp.McpServer` it emits one MCP tool class per `[ServiceCategory]`: a method with an
+  `action` parameter, the union of all parameters of that tool's actions (each nullable, since a
+  given action uses only some), and a body that packs those parameters under their wire names and
+  hands `category.action` to `ServiceBridge`.
+- In `WordMcp.Service` it emits the dispatcher that unpacks them again, applies the same defaults,
+  raises the same "x is required for this action." errors, and calls the command implementation.
+  It finds that implementation by looking for the class implementing the interface, so adding a
+  category needs no registry entry anywhere.
 
-`EmitCompilerGeneratedFiles` is on, so the output lands in `src/WordMcp.McpServer/obj/generated`
-and can be read like ordinary code. It is worth looking at once after adding a tool, to confirm
-that the description a client sees is the one that was written.
+The generator picks its half from the assembly name of the compilation it runs in, and is
+referenced as an analyzer by both projects.
+
+The session is resolved lazily, only once the dispatcher recognises the command. A misspelled
+command therefore reports that it is unknown instead of complaining about a missing `session_id`
+the caller never needed to supply.
+
+`EmitCompilerGeneratedFiles` is on for both projects, so the output lands in
+`src/WordMcp.McpServer/obj/generated` and `src/WordMcp.Service/obj/generated` and can be read like
+ordinary code. It is worth looking at once after adding a tool, to confirm that the description a
+client sees is the one that was written.
 
 Why generate: fifteen tools with close to seventy actions between them means the boilerplate is
 where the bugs would be, and a hand-written tool class drifts from its interface silently.
@@ -159,12 +183,15 @@ where the bugs would be, and a hand-written tool class drifts from its interface
 tool call
   → generated tool method
       → WordToolsBase.Execute(tool, action, …)      catch → JSON error
-          → WordToolsBase.Batch(session_id)         → SessionManager
-              → XyzCommands.Action(batch, args)
-                  → validate arguments              throws here on bad input
-                  → batch.Execute(word => …)        marshalled to the STA thread
-                      → Word COM
-                  ← result record
+          → ServiceBridge.Invoke("text.replace", session_id, { … })
+              → in-process, or one line down a named pipe
+                  → GeneratedToolDispatch                 → unknown command stops here
+                      → session lookup                    → SessionManager
+                      → XyzCommands.Action(batch, args)
+                          → validate arguments            throws here on bad input
+                          → batch.Execute(word => …)      marshalled to the STA thread
+                              → Word COM
+                          ← result record
           ← JSON
 ```
 

--- a/src/WordMcp.ComInterop/ComAssemblyResolver.cs
+++ b/src/WordMcp.ComInterop/ComAssemblyResolver.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using System.Runtime.Loader;
+
+namespace WordMcp.ComInterop;
+
+/// <summary>
+/// Resolves the Office interop assemblies from the application directory.
+/// </summary>
+/// <remarks>
+/// <para>Word is driven through <c>dynamic</c>, and the runtime binder needs the real interop
+/// assemblies to bind a member — including <c>office.dll</c>, which
+/// <c>Microsoft.Office.Interop.Word</c> refers to but which no package declares as a runtime
+/// dependency. The file is copied next to every executable, but a framework-dependent app only
+/// resolves what its deps file lists, so the load fails with a <see cref="FileNotFoundException"/>
+/// the moment the first dynamic call is bound.</para>
+/// <para>A test host hides this, because it probes its own directory. A plain executable does not,
+/// which is why the session service could not open a single document until this existed.</para>
+/// </remarks>
+internal static class ComAssemblyResolver
+{
+    private static readonly string[] Prefixes =
+    [
+        "office",
+        "stdole",
+        "Microsoft.Office.",
+        "Microsoft.Vbe."
+    ];
+
+    private static int _installed;
+
+    /// <summary>
+    /// Installs the resolver once. Called by the types that talk to Word, so no host has to know
+    /// this is necessary — forgetting it is exactly the bug this fixes.
+    /// </summary>
+    internal static void Install()
+    {
+        if (Interlocked.Exchange(ref _installed, 1) == 0)
+        {
+            AssemblyLoadContext.Default.Resolving += Resolve;
+        }
+    }
+
+    private static Assembly? Resolve(AssemblyLoadContext context, AssemblyName name)
+    {
+        // Deliberately narrow: this exists for the Office interop assemblies, and silently
+        // loading anything else that happens to sit in the directory would hide real problems.
+        if (name.Name is null || !Prefixes.Any(p => name.Name.StartsWith(p, StringComparison.OrdinalIgnoreCase)))
+        {
+            return null;
+        }
+
+        var candidate = Path.Combine(AppContext.BaseDirectory, name.Name + ".dll");
+        return File.Exists(candidate) ? context.LoadFromAssemblyPath(candidate) : null;
+    }
+}

--- a/src/WordMcp.ComInterop/Session/WordBatch.cs
+++ b/src/WordMcp.ComInterop/Session/WordBatch.cs
@@ -23,9 +23,14 @@ internal sealed class WordBatch : IWordBatch
     [DllImport("user32.dll")]
     private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
 
+    /// <summary>
+    /// Makes the Office interop assemblies loadable before the first dynamic call binds against
+    /// them. Doing it here rather than in each host is what keeps it from being forgotten.
+    /// </summary>
+    static WordBatch() => ComAssemblyResolver.Install();
+
     private readonly string _documentPath;
-    private readonly string[] _allDocumentPaths;
-    private readonly bool _visible;
+    private readonly string[] _allDocumentPaths;    private readonly bool _visible;
     private readonly bool _createNewFile;
     private readonly bool _isMacroEnabled;
     private readonly TimeSpan _operationTimeout;
@@ -268,8 +273,7 @@ internal sealed class WordBatch : IWordBatch
         catch (Exception ex)
         {
             started.TrySetException(ex);
-            CleanupCom();
-            OleMessageFilter.Revoke();
+            SafeCleanup();
             return;
         }
 #pragma warning restore CA1031
@@ -290,7 +294,33 @@ internal sealed class WordBatch : IWordBatch
         }
         finally
         {
+            SafeCleanup();
+        }
+    }
+
+    /// <summary>
+    /// Releases the COM objects without letting a failure escape.
+    /// </summary>
+    /// <remarks>
+    /// This runs on the STA thread, which has no caller to catch anything: an exception here does
+    /// not fail a session, it ends the whole process. That matters most in the service, where one
+    /// unlucky document would take every other session down with it. Whatever actually went wrong
+    /// has already been reported to the caller by this point.
+    /// </remarks>
+    private void SafeCleanup()
+    {
+        try
+        {
             CleanupCom();
+        }
+#pragma warning disable CA1031 // Nothing above this frame can handle a cleanup failure
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Releasing Word after '{Path}' failed", _documentPath);
+        }
+#pragma warning restore CA1031
+        finally
+        {
             OleMessageFilter.Revoke();
         }
     }

--- a/src/WordMcp.Generators.Mcp/McpToolGenerator.cs
+++ b/src/WordMcp.Generators.Mcp/McpToolGenerator.cs
@@ -15,21 +15,48 @@ namespace WordMcp.Generators.Mcp;
 public sealed class McpToolGenerator : IIncrementalGenerator
 {
     private const string ToolsNamespace = "WordMcp.McpServer.Tools";
-    private const string ServicesType = "WordMcp.McpServer.WordServices";
+    private const string ToolAssembly = "WordMcp.McpServer";
+    private const string ServiceAssembly = "WordMcp.Service";
+    private const string DispatchNamespace = "WordMcp.Service.Generated";
 
     /// <inheritdoc />
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var services = context.CompilationProvider.Select(static (compilation, _) => Discover(compilation));
+        var services = context.CompilationProvider.Select(static (compilation, _) =>
+            (Assembly: compilation.AssemblyName ?? string.Empty, Services: Discover(compilation)));
 
         context.RegisterSourceOutput(services, static (productionContext, discovered) =>
         {
-            foreach (var service in discovered)
+            // The same description feeds both halves of the boundary: the tool that packs the
+            // arguments and the dispatcher that unpacks them. Emitting them from one place is what
+            // keeps them from drifting apart.
+            switch (discovered.Assembly)
             {
-                string source = Emit(service);
-                productionContext.AddSource(
-                    $"WordTool.{service.Info.CategoryPascal}.g.cs",
-                    SourceText.From(source, Encoding.UTF8));
+                case ToolAssembly:
+                    foreach (var service in discovered.Services)
+                    {
+                        productionContext.AddSource(
+                            $"WordTool.{service.Info.CategoryPascal}.g.cs",
+                            SourceText.From(Emit(service.Info), Encoding.UTF8));
+                    }
+
+                    break;
+
+                case ServiceAssembly:
+                    foreach (var service in discovered.Services)
+                    {
+                        productionContext.AddSource(
+                            $"WordDispatch.{service.Info.CategoryPascal}.g.cs",
+                            SourceText.From(EmitDispatch(service), Encoding.UTF8));
+                    }
+
+                    productionContext.AddSource(
+                        "GeneratedToolDispatch.g.cs",
+                        SourceText.From(EmitAggregator(discovered.Services), Encoding.UTF8));
+                    break;
+
+                default:
+                    break;
             }
         });
     }
@@ -40,9 +67,10 @@ public sealed class McpToolGenerator : IIncrementalGenerator
     /// </summary>
     private static ImmutableArray<DiscoveredService> Discover(Compilation compilation)
     {
-        var servicesByInterface = MapServiceProperties(compilation);
         var documentation = DocumentationSource.Load(compilation, "WordMcp.");
         var builder = ImmutableArray.CreateBuilder<DiscoveredService>();
+        var candidates = new List<INamedTypeSymbol>();
+        var implementations = new List<INamedTypeSymbol>();
 
         foreach (var reference in compilation.References)
         {
@@ -60,53 +88,49 @@ public sealed class McpToolGenerator : IIncrementalGenerator
 
             foreach (var type in EnumerateTypes(assembly.GlobalNamespace))
             {
-                if (type.TypeKind != TypeKind.Interface)
+                if (type.TypeKind == TypeKind.Interface)
                 {
-                    continue;
+                    candidates.Add(type);
                 }
-
-                var info = ServiceInfoExtractor.Extract(type, documentation);
-                if (info is null)
+                else if (type is { TypeKind: TypeKind.Class, IsAbstract: false, DeclaredAccessibility: Accessibility.Public })
                 {
-                    continue;
+                    implementations.Add(type);
                 }
-
-                if (!servicesByInterface.TryGetValue(info.InterfaceName, out string? property))
-                {
-                    property = Pluralize(info.CategoryPascal);
-                }
-
-                builder.Add(new DiscoveredService(info, property));
             }
+        }
+
+        foreach (var type in candidates)
+        {
+            var info = ServiceInfoExtractor.Extract(type, documentation);
+            if (info is null)
+            {
+                continue;
+            }
+
+            builder.Add(new DiscoveredService(info, FindImplementation(implementations, type)));
         }
 
         return builder.ToImmutable();
     }
 
     /// <summary>
-    /// Reads the static WordServices class and maps each command interface to the property that
-    /// returns it, so the generated dispatch never has to guess a name.
+    /// Finds the class implementing a command interface, so the dispatch half can construct it
+    /// without a hand-maintained registry that would have to be edited for every new category.
     /// </summary>
-    private static Dictionary<string, string> MapServiceProperties(Compilation compilation)
+    private static string? FindImplementation(List<INamedTypeSymbol> classes, INamedTypeSymbol interfaceSymbol)
     {
-        var map = new Dictionary<string, string>(StringComparer.Ordinal);
-        var services = compilation.GetTypeByMetadataName(ServicesType);
-
-        if (services is null)
+        foreach (var candidate in classes)
         {
-            return map;
-        }
-
-        foreach (var member in services.GetMembers())
-        {
-            if (member is IPropertySymbol { IsStatic: true } property
-                && property.Type.TypeKind == TypeKind.Interface)
+            foreach (var implemented in candidate.AllInterfaces)
             {
-                map[property.Type.Name] = property.Name;
+                if (SymbolEqualityComparer.Default.Equals(implemented, interfaceSymbol))
+                {
+                    return candidate.ToDisplayString();
+                }
             }
         }
 
-        return map;
+        return null;
     }
 
     private static IEnumerable<INamedTypeSymbol> EnumerateTypes(INamespaceSymbol root)
@@ -127,54 +151,8 @@ public sealed class McpToolGenerator : IIncrementalGenerator
         }
     }
 
-    /// <summary>
-    /// Fallback naming when WordServices does not expose the interface. "HeaderFooter" becomes
-    /// "HeadersFooters" because each word is pluralized on its own.
-    /// </summary>
-    private static string Pluralize(string pascalName)
+    private static string Emit(ServiceInfo info)
     {
-        var words = SplitWords(pascalName);
-        var sb = new StringBuilder();
-
-        foreach (string word in words)
-        {
-            sb.Append(word);
-            if (!word.EndsWith("s", StringComparison.Ordinal))
-            {
-                sb.Append('s');
-            }
-        }
-
-        return sb.ToString();
-    }
-
-    private static List<string> SplitWords(string pascalName)
-    {
-        var words = new List<string>();
-        var current = new StringBuilder();
-
-        foreach (char c in pascalName)
-        {
-            if (char.IsUpper(c) && current.Length > 0)
-            {
-                words.Add(current.ToString());
-                current.Clear();
-            }
-
-            current.Append(c);
-        }
-
-        if (current.Length > 0)
-        {
-            words.Add(current.ToString());
-        }
-
-        return words;
-    }
-
-    private static string Emit(DiscoveredService service)
-    {
-        var info = service.Info;
         var exposed = ServiceInfoExtractor.GetExposedParameters(info);
         string enumName = $"Word{info.CategoryPascal}Action";
         string className = $"Word{info.CategoryPascal}Tool";
@@ -192,7 +170,7 @@ public sealed class McpToolGenerator : IIncrementalGenerator
         sb.AppendLine();
 
         EmitEnum(sb, info, enumName);
-        EmitTool(sb, service, exposed, enumName, className);
+        EmitTool(sb, info, exposed, enumName, className);
 
         return sb.ToString();
     }
@@ -227,12 +205,11 @@ public sealed class McpToolGenerator : IIncrementalGenerator
 
     private static void EmitTool(
         StringBuilder sb,
-        DiscoveredService service,
+        ServiceInfo info,
         List<ExposedParameter> exposed,
         string enumName,
         string className)
     {
-        var info = service.Info;
         string methodName = info.CategoryPascal;
 
         sb.AppendLine("/// <summary>");
@@ -285,21 +262,29 @@ public sealed class McpToolGenerator : IIncrementalGenerator
         }
 
         sb.AppendLine(")");
-        sb.AppendLine($"        => WordToolsBase.Execute(\"{info.ToolName}\", action.ToString(), () =>");
-        sb.AppendLine("        {");
-        sb.AppendLine("            var batch = WordToolsBase.Batch(session_id);");
-        sb.AppendLine();
-        sb.AppendLine("            return action switch");
+        sb.AppendLine($"        => WordToolsBase.Execute(\"{info.ToolName}\", action.ToString(), () => ServiceBridge.Invoke(");
+        sb.AppendLine("            action switch");
         sb.AppendLine("            {");
 
         foreach (var method in info.Methods)
         {
-            EmitCase(sb, service, method, enumName, exposed);
+            sb.AppendLine($"                {enumName}.{method.ActionPascal} => \"{info.ToolName}.{method.ActionName}\",");
         }
 
         sb.AppendLine("                _ => throw new ArgumentException($\"Unknown action '{action}'.\", nameof(action))");
-        sb.AppendLine("            };");
-        sb.AppendLine("        });");
+        sb.AppendLine("            },");
+        sb.AppendLine("            session_id,");
+
+        // The arguments travel as a plain object whose property names are the wire names, so the
+        // dispatcher on the other side reads them back under the names the caller typed.
+        sb.AppendLine("            new");
+        sb.AppendLine("            {");
+        for (int i = 0; i < exposed.Count; i++)
+        {
+            sb.AppendLine($"                {exposed[i].WireName}{(i == exposed.Count - 1 ? string.Empty : ",")}");
+        }
+
+        sb.AppendLine("            }));");
         sb.AppendLine("}");
     }
 
@@ -319,71 +304,174 @@ public sealed class McpToolGenerator : IIncrementalGenerator
         sb.Append($"        [DefaultValue(null)] {type} {parameter.WireName} = null");
     }
 
-    private static void EmitCase(
-        StringBuilder sb,
-        DiscoveredService service,
-        MethodInfo method,
-        string enumName,
-        List<ExposedParameter> exposed)
+    /// <summary>
+    /// Emits the dispatch half: the class that unpacks one category's arguments and calls the
+    /// command implementation. This is the code the tool half talks to across the boundary.
+    /// </summary>
+    private static string EmitDispatch(DiscoveredService service)
     {
-        var arguments = new List<string> { "batch" };
+        var info = service.Info;
+        var exposed = ServiceInfoExtractor.GetExposedParameters(info);
 
-        foreach (var parameter in method.Parameters)
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Text.Json;");
+        sb.AppendLine("using WordMcp.ComInterop.Session;");
+        sb.AppendLine();
+        sb.AppendLine($"namespace {DispatchNamespace};");
+        sb.AppendLine();
+        sb.AppendLine($"/// <summary>Runs the actions of the <c>{Escape(info.ToolName)}</c> tool.</summary>");
+        sb.AppendLine($"internal static class {info.CategoryPascal}Dispatch");
+        sb.AppendLine("{");
+
+        if (service.Implementation is null)
         {
-            var declared = exposed.Find(p => p.Name == parameter.Name)!;
-            arguments.Add(BuildArgument(parameter, declared));
+            // No implementation in reach: emit a dispatcher that declines everything rather than
+            // failing the build, so a partially wired category cannot break the whole service.
+            sb.AppendLine("    /// <summary>Always declines: no implementation was found.</summary>");
+            sb.AppendLine("    internal static bool TryInvoke(string action, Func<IWordBatch> batch, JsonElement args, out object? result)");
+            sb.AppendLine("    {");
+            sb.AppendLine("        result = null;");
+            sb.AppendLine("        return false;");
+            sb.AppendLine("    }");
+            sb.AppendLine("}");
+            return sb.ToString();
         }
 
-        string call = $"WordServices.{service.ServiceProperty}.{method.MethodName}({string.Join(", ", arguments)})";
-        string line = $"                {enumName}.{method.ActionPascal} => {call},";
+        sb.AppendLine($"    private static readonly {info.InterfaceNamespace}.{info.InterfaceName} Commands");
+        sb.AppendLine($"        = new {service.Implementation}();");
+        sb.AppendLine();
+        sb.AppendLine("    /// <summary>Runs one action against an open document.</summary>");
+        sb.AppendLine("    /// <param name=\"action\">The action name without the category prefix.</param>");
+        sb.AppendLine("    /// <param name=\"batch\">Resolves the session, but only once the action is known.</param>");
+        sb.AppendLine("    /// <param name=\"args\">The arguments as the tool packed them.</param>");
+        sb.AppendLine("    /// <param name=\"result\">The action's result when it ran.</param>");
+        sb.AppendLine("    /// <returns><c>true</c> when the action is known to this category.</returns>");
+        sb.AppendLine("    internal static bool TryInvoke(string action, Func<IWordBatch> batch, JsonElement args, out object? result)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        switch (action)");
+        sb.AppendLine("        {");
 
-        if (line.Length <= 118)
+        foreach (var method in info.Methods)
         {
-            sb.AppendLine(line);
-            return;
+            var arguments = new List<string> { "batch()" };
+            foreach (var parameter in method.Parameters)
+            {
+                arguments.Add(BuildDispatchArgument(parameter, exposed.Find(p => p.Name == parameter.Name)!));
+            }
+
+            sb.AppendLine($"            case \"{method.ActionName}\":");
+            sb.AppendLine($"                result = Commands.{method.MethodName}(");
+            for (int i = 0; i < arguments.Count; i++)
+            {
+                sb.AppendLine($"                    {arguments[i]}{(i == arguments.Count - 1 ? ");" : ",")}");
+            }
+
+            sb.AppendLine("                return true;");
+            sb.AppendLine();
         }
 
-        sb.AppendLine($"                {enumName}.{method.ActionPascal} => WordServices.{service.ServiceProperty}.{method.MethodName}(");
-        for (int i = 0; i < arguments.Count; i++)
-        {
-            sb.AppendLine($"                    {arguments[i]}{(i == arguments.Count - 1 ? "),": ",")}");
-        }
+        sb.AppendLine("            default:");
+        sb.AppendLine("                result = null;");
+        sb.AppendLine("                return false;");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        return sb.ToString();
     }
 
     /// <summary>
-    /// Builds the argument expression for one parameter, bridging the gap between the optional
-    /// tool parameter and what the command method actually accepts.
+    /// Emits the one entry point the service calls: it splits <c>category.action</c> and hands the
+    /// work to the matching category.
     /// </summary>
-    private static string BuildArgument(ParameterInfo parameter, ExposedParameter declared)
+    private static string EmitAggregator(ImmutableArray<DiscoveredService> services)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("// <auto-generated/>");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine();
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Text.Json;");
+        sb.AppendLine("using WordMcp.ComInterop.Session;");
+        sb.AppendLine();
+        sb.AppendLine($"namespace {DispatchNamespace};");
+        sb.AppendLine();
+        sb.AppendLine("/// <summary>Routes a tool command to the category that implements it.</summary>");
+        sb.AppendLine("internal static class GeneratedToolDispatch");
+        sb.AppendLine("{");
+        sb.AppendLine("    /// <summary>Runs a <c>category.action</c> command against an open document.</summary>");
+        sb.AppendLine("    /// <param name=\"command\">The command name, for example <c>text.insert</c>.</param>");
+        sb.AppendLine("    /// <param name=\"batch\">Resolves the session, but only once the command is known.</param>");
+        sb.AppendLine("    /// <param name=\"args\">The arguments as the tool packed them.</param>");
+        sb.AppendLine("    /// <param name=\"result\">The command's result when it ran.</param>");
+        sb.AppendLine("    /// <returns><c>true</c> when the command is known.</returns>");
+        sb.AppendLine("    internal static bool TryInvoke(string command, Func<IWordBatch> batch, JsonElement args, out object? result)");
+        sb.AppendLine("    {");
+        sb.AppendLine("        int separator = command.IndexOf('.');");
+        sb.AppendLine("        if (separator <= 0)");
+        sb.AppendLine("        {");
+        sb.AppendLine("            result = null;");
+        sb.AppendLine("            return false;");
+        sb.AppendLine("        }");
+        sb.AppendLine();
+        sb.AppendLine("        string action = command.Substring(separator + 1);");
+        sb.AppendLine();
+        sb.AppendLine("        switch (command.Substring(0, separator))");
+        sb.AppendLine("        {");
+
+        foreach (var service in services)
+        {
+            sb.AppendLine($"            case \"{service.Info.ToolName}\":");
+            sb.AppendLine($"                return {service.Info.CategoryPascal}Dispatch.TryInvoke(action, batch, args, out result);");
+        }
+
+        sb.AppendLine("            default:");
+        sb.AppendLine("                result = null;");
+        sb.AppendLine("                return false;");
+        sb.AppendLine("        }");
+        sb.AppendLine("    }");
+        sb.AppendLine("}");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Builds the argument expression on the dispatch side: reads the value back out of the JSON
+    /// the tool sent, and reproduces the same fallbacks and the same errors the tool used to raise.
+    /// </summary>
+    private static string BuildDispatchArgument(ParameterInfo parameter, ExposedParameter declared)
     {
         string name = declared.WireName;
+        string bare = parameter.TypeName.TrimEnd('?');
+        bool isValueType = bare is "int" or "long" or "double" or "float" or "decimal" or "bool";
+        string read = isValueType ? $"ToolArgs.Val<{bare}>(args, \"{name}\")" : $"ToolArgs.Ref<{bare}>(args, \"{name}\")";
 
-        // The declared parameter kept its non-nullable type, so it always carries a usable value.
+        // The tool declared the parameter non-nullable, so every action agrees on a fallback.
         if (declared.CanStayNonNullable)
         {
-            return name;
+            return $"{read} ?? {declared.DefaultValue}";
         }
 
         // The command accepts null itself, so nothing has to be substituted.
         if (parameter.TypeName.EndsWith("?", StringComparison.Ordinal))
         {
-            return name;
+            return read;
         }
 
         // The command declares a default, so an omitted value falls back to it.
         if (parameter.HasDefault && parameter.DefaultValue != null)
         {
-            return $"{name} ?? {parameter.DefaultValue}";
+            return $"{read} ?? {parameter.DefaultValue}";
         }
 
         // The command needs a value and has no fallback, so the omission has to become an error.
-        return parameter.TypeName switch
-        {
-            "string" => $"WordToolsBase.RequireText({name}, nameof({name}))",
-            "int" or "double" or "bool" or "long" or "float" or "decimal"
-                => $"WordToolsBase.Require({name}, nameof({name}))",
-            _ => $"WordToolsBase.RequireValue({name}, nameof({name}))"
-        };
+        return isValueType
+            ? $"ToolArgs.RequireVal<{bare}>(args, \"{name}\")"
+            : $"ToolArgs.RequireRef<{bare}>(args, \"{name}\")";
     }
 
     private static string Escape(string text)
@@ -394,15 +482,15 @@ public sealed class McpToolGenerator : IIncrementalGenerator
 
     private sealed class DiscoveredService
     {
-        public DiscoveredService(ServiceInfo info, string serviceProperty)
+        public DiscoveredService(ServiceInfo info, string? implementation)
         {
             Info = info;
-            ServiceProperty = serviceProperty;
+            Implementation = implementation;
         }
 
         public ServiceInfo Info { get; }
 
-        /// <summary>Name of the WordServices property that returns the command interface.</summary>
-        public string ServiceProperty { get; }
+        /// <summary>Fully qualified name of the class implementing the interface, if one was found.</summary>
+        public string? Implementation { get; }
     }
 }

--- a/src/WordMcp.McpServer/ServiceBridge.cs
+++ b/src/WordMcp.McpServer/ServiceBridge.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using WordMcp.ComInterop.Session;
 using WordMcp.Service;
 
 namespace WordMcp.McpServer;
@@ -12,18 +11,35 @@ namespace WordMcp.McpServer;
 /// copy of open, create, save, close, list and test. Two implementations of the same rules drift,
 /// and the one the user hits is decided by which entry point they came through. Everything session
 /// shaped now goes through here, so there is one answer.</para>
-/// <para>The bridge is in-process: it holds a <see cref="WordMcpService"/> and calls it directly.
-/// The point of routing through it anyway is that the calls are already data only, which is what a
-/// later move onto the pipe needs. What cannot cross yet is <see cref="Batch"/> — an
-/// <see cref="IWordBatch"/> is a live COM handle, and the generated tools still need one.</para>
+/// <para>Nothing crossing this seam is anything but data. That is what lets the same call run
+/// in-process or travel down a named pipe to a daemon, chosen by <c>WORDMCP_SERVICE_MODE</c>,
+/// without a single tool knowing which one it got.</para>
 /// </remarks>
 internal static class ServiceBridge
 {
+    /// <summary>Environment variable that selects in-process or daemon operation.</summary>
+    public const string ModeVariable = "WORDMCP_SERVICE_MODE";
+
     private static readonly Lock Gate = new();
     private static WordMcpService? _service;
+    private static ServiceClient? _client;
 
     /// <summary>
-    /// Gets the service, creating it on first use so an idle server never starts Word.
+    /// Gets a value indicating whether commands travel to a separate daemon process.
+    /// </summary>
+    /// <remarks>
+    /// In-process is the default because it is what a single client wants: no second process, no
+    /// pipe, no startup wait. Daemon mode is for the case the in-process one cannot serve at all —
+    /// several clients that have to see the same open document.
+    /// </remarks>
+    public static bool UseDaemon
+        => string.Equals(
+            Environment.GetEnvironmentVariable(ModeVariable),
+            "daemon",
+            StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets the in-process service, creating it on first use so an idle server never starts Word.
     /// </summary>
     public static WordMcpService Service
     {
@@ -37,16 +53,9 @@ internal static class ServiceBridge
     }
 
     /// <summary>
-    /// Resolves the batch behind a session id.
-    /// </summary>
-    /// <param name="sessionId">The session identifier supplied by the caller.</param>
-    /// <returns>The batch for that session.</returns>
-    public static IWordBatch Batch(string? sessionId) => Service.GetBatch(sessionId);
-
-    /// <summary>
     /// Runs one service command and returns its payload.
     /// </summary>
-    /// <param name="command">The command name, for example <c>session.open</c>.</param>
+    /// <param name="command">The command name, for example <c>session.open</c> or <c>text.insert</c>.</param>
     /// <param name="sessionId">The session the command applies to, when it is session scoped.</param>
     /// <param name="args">Arguments, serialized as the command's argument object.</param>
     /// <returns>The result payload, ready to be serialized into the tool response.</returns>
@@ -64,7 +73,9 @@ internal static class ServiceBridge
         // The service is asynchronous because a pipe host needs it to be; in-process the only
         // await is the open gate, and blocking on it here is what keeps the tool signatures
         // synchronous for the MCP SDK.
-        var response = Service.ProcessAsync(request).GetAwaiter().GetResult();
+        var response = UseDaemon
+            ? Client.SendAsync(request).GetAwaiter().GetResult()
+            : Service.ProcessAsync(request).GetAwaiter().GetResult();
 
         if (!response.Success)
         {
@@ -81,12 +92,31 @@ internal static class ServiceBridge
     /// <summary>
     /// Saves and closes every open session. Called on shutdown so unsaved work is not lost.
     /// </summary>
+    /// <remarks>
+    /// In daemon mode this deliberately leaves the sessions alone: outliving one client is the
+    /// entire point of the daemon, and the idle timeout is what ends its life.
+    /// </remarks>
     public static void Shutdown()
     {
         lock (Gate)
         {
             _service?.Dispose();
             _service = null;
+            _client?.Dispose();
+            _client = null;
+        }
+    }
+
+    private static ServiceClient Client
+    {
+        get
+        {
+            lock (Gate)
+            {
+                return _client ??= new ServiceClient(
+                    ServiceSecurity.GetServicePipeName(),
+                    logger: WordServices.Logger);
+            }
         }
     }
 }

--- a/src/WordMcp.McpServer/Tools/WordToolsBase.cs
+++ b/src/WordMcp.McpServer/Tools/WordToolsBase.cs
@@ -58,14 +58,6 @@ internal static class WordToolsBase
         => JsonSerializer.Serialize(value, JsonOptions);
 
     /// <summary>
-    /// Resolves the batch for a session id, with a helpful error when the id is missing.
-    /// </summary>
-    /// <param name="sessionId">The session id supplied by the caller.</param>
-    /// <returns>The batch for that session.</returns>
-    public static IWordBatch Batch(string? sessionId)
-        => ServiceBridge.Batch(sessionId);
-
-    /// <summary>
     /// Validates that a path is an absolute Windows path with a supported extension.
     /// </summary>
     /// <param name="path">The path to validate.</param>
@@ -102,40 +94,6 @@ internal static class WordToolsBase
 
         return fullPath;
     }
-
-    /// <summary>
-    /// Unwraps a value type an action cannot run without.
-    /// </summary>
-    /// <typeparam name="T">The underlying value type.</typeparam>
-    /// <param name="value">The value supplied by the caller.</param>
-    /// <param name="name">Parameter name, used in the error message.</param>
-    /// <returns>The value.</returns>
-    public static T Require<T>(T? value, string name)
-        where T : struct
-        => value ?? throw new ArgumentException($"{name} is required for this action.", name);
-
-    /// <summary>
-    /// Unwraps a reference type an action cannot run without.
-    /// </summary>
-    /// <typeparam name="T">The reference type.</typeparam>
-    /// <param name="value">The value supplied by the caller.</param>
-    /// <param name="name">Parameter name, used in the error message.</param>
-    /// <returns>The value.</returns>
-    public static T RequireValue<T>(T? value, string name)
-        where T : class
-        => value ?? throw new ArgumentException($"{name} is required for this action.", name);
-
-    /// <summary>
-    /// Unwraps a string an action cannot run without. Blank counts as missing, because a
-    /// whitespace-only style or bookmark name is never what the caller meant.
-    /// </summary>
-    /// <param name="value">The value supplied by the caller.</param>
-    /// <param name="name">Parameter name, used in the error message.</param>
-    /// <returns>The value.</returns>
-    public static string RequireText(string? value, string name)
-        => string.IsNullOrWhiteSpace(value)
-            ? throw new ArgumentException($"{name} is required for this action.", name)
-            : value;
 
     private static string Describe(Exception ex) => ex switch    {
         KeyNotFoundException => ex.Message,

--- a/src/WordMcp.McpServer/WordServices.cs
+++ b/src/WordMcp.McpServer/WordServices.cs
@@ -1,73 +1,18 @@
 using Microsoft.Extensions.Logging;
-using WordMcp.Core.Commands.Document;
-using WordMcp.Core.Commands.Bookmark;
-using WordMcp.Core.Commands.Comment;
-using WordMcp.Core.Commands.Screenshot;
-using WordMcp.Core.Commands.Field;
-using WordMcp.Core.Commands.HeaderFooter;
-using WordMcp.Core.Commands.Image;
-using WordMcp.Core.Commands.List;
-using WordMcp.Core.Commands.Paragraph;
-using WordMcp.Core.Commands.Revision;
-using WordMcp.Core.Commands.Section;
-using WordMcp.Core.Commands.Style;
-using WordMcp.Core.Commands.Table;
-using WordMcp.Core.Commands.Text;
 
 namespace WordMcp.McpServer;
 
 /// <summary>
-/// Process-wide singletons used by the MCP tools.
+/// Process-wide state used by the MCP tools.
 /// </summary>
 /// <remarks>
-/// The MCP SDK discovers tools as static methods, so the command implementations are held here
-/// instead of being resolved through DI. Sessions are not: they belong to
-/// <see cref="ServiceBridge"/>, which is the only thing in the process that owns one.
+/// The MCP SDK discovers tools as static methods, so what little the tools share cannot be
+/// resolved through DI and lives here instead. That is now only the logger: the command
+/// implementations moved behind <see cref="ServiceBridge"/>, and so did the sessions, because a
+/// tool that holds neither can run against a document in another process.
 /// </remarks>
 internal static class WordServices
 {
     /// <summary>Gets or sets the logger handed to new sessions.</summary>
     public static ILogger? Logger { get; set; }
-
-    /// <summary>Gets the document command implementation.</summary>
-    public static IDocumentCommands Documents { get; } = new DocumentCommands();
-
-    /// <summary>Gets the text command implementation.</summary>
-    public static ITextCommands Texts { get; } = new TextCommands();
-
-    /// <summary>Gets the paragraph command implementation.</summary>
-    public static IParagraphCommands Paragraphs { get; } = new ParagraphCommands();
-
-    /// <summary>Gets the table command implementation.</summary>
-    public static ITableCommands Tables { get; } = new TableCommands();
-
-    /// <summary>Gets the image command implementation.</summary>
-    public static IImageCommands Images { get; } = new ImageCommands();
-
-    /// <summary>Gets the field command implementation.</summary>
-    public static IFieldCommands Fields { get; } = new FieldCommands();
-
-    /// <summary>Gets the section command implementation.</summary>
-    public static ISectionCommands Sections { get; } = new SectionCommands();
-
-    /// <summary>Gets the header and footer command implementation.</summary>
-    public static IHeaderFooterCommands HeadersFooters { get; } = new HeaderFooterCommands();
-
-    /// <summary>Gets the style command implementation.</summary>
-    public static IStyleCommands Styles { get; } = new StyleCommands();
-
-    /// <summary>Gets the list command implementation.</summary>
-    public static IListCommands Lists { get; } = new ListCommands();
-
-    /// <summary>Gets the comment command implementation.</summary>
-    public static ICommentCommands Comments { get; } = new CommentCommands();
-
-    /// <summary>Gets the revision command implementation.</summary>
-    public static IRevisionCommands Revisions { get; } = new RevisionCommands();
-
-    /// <summary>Gets the bookmark command implementation.</summary>
-    public static IBookmarkCommands Bookmarks { get; } = new BookmarkCommands();
-
-    /// <summary>Gets the screenshot command implementation.</summary>
-    public static IScreenshotCommands Screenshots { get; } = new ScreenshotCommands();
 }

--- a/src/WordMcp.Service/ToolArgs.cs
+++ b/src/WordMcp.Service/ToolArgs.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+
+namespace WordMcp.Service;
+
+/// <summary>
+/// Reads tool arguments back out of the JSON object the MCP server sent.
+/// </summary>
+/// <remarks>
+/// The tool layer packs its parameters under their wire names and drops the ones the caller
+/// omitted, so every read here has to cope with an absent property. The error messages repeat
+/// what the tool layer used to say word for word: the caller names a parameter, not a transport,
+/// and should not be able to tell which side of the process boundary noticed the omission.
+/// </remarks>
+public static class ToolArgs
+{
+    /// <summary>
+    /// Reads an optional value-typed argument.
+    /// </summary>
+    /// <typeparam name="T">The value type to read.</typeparam>
+    /// <param name="args">The argument object.</param>
+    /// <param name="name">The wire name of the argument.</param>
+    /// <returns>The value, or <c>null</c> when the caller omitted it.</returns>
+    public static T? Val<T>(JsonElement args, string name)
+        where T : struct
+        => TryGet(args, name, out var property) ? property.Deserialize<T>(ServiceProtocol.JsonOptions) : null;
+
+    /// <summary>
+    /// Reads an optional reference-typed argument.
+    /// </summary>
+    /// <typeparam name="T">The reference type to read.</typeparam>
+    /// <param name="args">The argument object.</param>
+    /// <param name="name">The wire name of the argument.</param>
+    /// <returns>The value, or <c>null</c> when the caller omitted it.</returns>
+    public static T? Ref<T>(JsonElement args, string name)
+        where T : class
+        => TryGet(args, name, out var property) ? property.Deserialize<T>(ServiceProtocol.JsonOptions) : null;
+
+    /// <summary>
+    /// Reads a value-typed argument the action cannot run without.
+    /// </summary>
+    /// <typeparam name="T">The value type to read.</typeparam>
+    /// <param name="args">The argument object.</param>
+    /// <param name="name">The wire name of the argument.</param>
+    /// <returns>The value.</returns>
+    /// <exception cref="ArgumentException">The caller omitted the argument.</exception>
+    public static T RequireVal<T>(JsonElement args, string name)
+        where T : struct
+        => Val<T>(args, name) ?? throw Missing(name);
+
+    /// <summary>
+    /// Reads a reference-typed argument the action cannot run without. A blank string counts as
+    /// missing, because a whitespace-only style or bookmark name is never what the caller meant.
+    /// </summary>
+    /// <typeparam name="T">The reference type to read.</typeparam>
+    /// <param name="args">The argument object.</param>
+    /// <param name="name">The wire name of the argument.</param>
+    /// <returns>The value.</returns>
+    /// <exception cref="ArgumentException">The caller omitted the argument.</exception>
+    public static T RequireRef<T>(JsonElement args, string name)
+        where T : class
+    {
+        var value = Ref<T>(args, name);
+        if (value is null || (value is string text && string.IsNullOrWhiteSpace(text)))
+        {
+            throw Missing(name);
+        }
+
+        return value;
+    }
+
+    private static bool TryGet(JsonElement args, string name, out JsonElement property)
+    {
+        if (args.ValueKind != JsonValueKind.Object
+            || !args.TryGetProperty(name, out property)
+            || property.ValueKind == JsonValueKind.Null)
+        {
+            property = default;
+            return false;
+        }
+
+        return true;
+    }
+
+    private static ArgumentException Missing(string name)
+        => new($"{name} is required for this action.", name);
+}

--- a/src/WordMcp.Service/WordMcp.Service.csproj
+++ b/src/WordMcp.Service/WordMcp.Service.csproj
@@ -7,6 +7,10 @@
     <AssemblyName>WordMcp.Service</AssemblyName>
     <RootNamespace>WordMcp.Service</RootNamespace>
 
+    <!-- Write the generated dispatch classes to disk so they can be reviewed in a diff -->
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)generated</CompilerGeneratedFilesOutputPath>
+
     <PackageId>WordMcp.Service</PackageId>
     <Title>WordMcp Session Service</Title>
     <Description>Holds Word sessions outside the MCP server process so several clients can share one open document. Provides the request/response protocol, per-user named pipe security and the session lifecycle.</Description>
@@ -24,6 +28,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\WordMcp.ComInterop\WordMcp.ComInterop.csproj" />
+    <ProjectReference Include="..\WordMcp.Core\WordMcp.Core.csproj" />
+    <ProjectReference Include="..\WordMcp.Generators.Mcp\WordMcp.Generators.Mcp.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WordMcp.Service/WordMcpService.cs
+++ b/src/WordMcp.Service/WordMcpService.cs
@@ -1,7 +1,9 @@
 using System.Globalization;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using WordMcp.ComInterop;
 using WordMcp.ComInterop.Session;
+using WordMcp.Service.Generated;
 
 namespace WordMcp.Service;
 
@@ -168,9 +170,32 @@ public sealed class WordMcpService : IDisposable
             "session.close" => Close(request.SessionId, Args(request).Save ?? true),
             "session.list" => List(),
             "session.test" => Test(Args(request).FilePath),
-            _ => ServiceResponse.Fail(
-                $"Unknown command '{request.Command}'.", nameof(NotSupportedException))
+            _ => InvokeTool(request)
         };
+
+    /// <summary>
+    /// Runs a generated tool command against an open session.
+    /// </summary>
+    /// <remarks>
+    /// Everything the service does not handle itself is a tool command. The session is resolved
+    /// lazily, so a misspelled command is reported as unknown instead of complaining about a
+    /// session the caller never needed to supply.
+    /// </remarks>
+    private ServiceResponse InvokeTool(ServiceRequest request)
+    {
+        using var document = string.IsNullOrWhiteSpace(request.Args)
+            ? JsonDocument.Parse("{}")
+            : JsonDocument.Parse(request.Args!);
+
+        return GeneratedToolDispatch.TryInvoke(
+            request.Command,
+            () => GetBatch(request.SessionId),
+            document.RootElement,
+            out var result)
+            ? ServiceResponse.Ok(result ?? new { success = true })
+            : ServiceResponse.Fail(
+                $"Unknown command '{request.Command}'.", nameof(NotSupportedException));
+    }
 
     private static SessionArgs Args(ServiceRequest request)
         => (request.Args is null ? null : ServiceProtocol.Deserialize<SessionArgs>(request.Args)) ?? new SessionArgs();

--- a/tests/WordMcp.McpServer.Tests/GeneratedToolIntegrationTests.cs
+++ b/tests/WordMcp.McpServer.Tests/GeneratedToolIntegrationTests.cs
@@ -1,0 +1,113 @@
+using System.Text.Json;
+using WordMcp.McpServer.Tools;
+using Xunit;
+
+namespace WordMcp.McpServer.Tests;
+
+/// <summary>
+/// The generated tools no longer touch a COM object: they pack their arguments, hand them to the
+/// bridge and read a result back. These tests are what proves that packing and unpacking agree,
+/// because nothing else does — a mismatched name or a dropped default only shows up when a real
+/// document comes back changed. Requires Word.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class GeneratedToolIntegrationTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(Path.GetTempPath(), $"wordmcp-generated-{Guid.NewGuid():N}");
+
+    public GeneratedToolIntegrationTests() => Directory.CreateDirectory(_directory);
+
+    public void Dispose()
+    {
+        ServiceBridge.Shutdown();
+        Environment.SetEnvironmentVariable(ServiceBridge.ModeVariable, null);
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Word may still be releasing the file; the temp directory is disposable anyway.
+        }
+    }
+
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement.Clone();
+
+    [Fact]
+    public void TextWrittenThroughAToolComesBackThroughAnother()
+    {
+        var path = Path.Combine(_directory, "generated.docx");
+        var created = Parse(WordFileTool.File(WordFileAction.Create, path));
+        Assert.True(created.GetProperty("success").GetBoolean(), created.ToString());
+        var session = created.GetProperty("sessionId").GetString()!;
+
+        try
+        {
+            var appended = Parse(WordTextTool.Text(WordTextAction.Append, session, text: "Guten Morgen."));
+            Assert.True(appended.GetProperty("success").GetBoolean(), appended.ToString());
+
+            var read = Parse(WordTextTool.Text(WordTextAction.Get, session));
+            Assert.Contains("Guten Morgen.", read.GetProperty("text").GetString(), StringComparison.Ordinal);
+
+            // A replace exercises the arguments that carry a default on both sides of the seam.
+            var replaced = Parse(WordTextTool.Text(
+                WordTextAction.Replace, session, search_text: "Morgen", replace_text: "Abend"));
+            Assert.True(replaced.GetProperty("success").GetBoolean(), replaced.ToString());
+
+            var after = Parse(WordTextTool.Text(WordTextAction.Get, session));
+            Assert.Contains("Guten Abend.", after.GetProperty("text").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            WordFileTool.File(WordFileAction.Close, session_id: session, save: false);
+        }
+    }
+
+    [Fact]
+    public void AMissingArgumentIsStillTheCallersParameterName()
+    {
+        var path = Path.Combine(_directory, "missing.docx");
+        var session = Parse(WordFileTool.File(WordFileAction.Create, path)).GetProperty("sessionId").GetString()!;
+
+        try
+        {
+            // add needs a name; the message has to name the parameter the caller typed, not
+            // whatever the service calls it internally.
+            var failed = Parse(WordBookmarkTool.Bookmark(WordBookmarkAction.Add, session, paragraph_index: 1));
+
+            Assert.False(failed.GetProperty("success").GetBoolean());
+            Assert.Equal("ArgumentException", failed.GetProperty("errorType").GetString());
+            Assert.Contains("name is required", failed.GetProperty("errorMessage").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            WordFileTool.File(WordFileAction.Close, session_id: session, save: false);
+        }
+    }
+
+    [Fact]
+    public void TheSameToolWorksThroughTheDaemon()
+    {
+        Environment.SetEnvironmentVariable(ServiceBridge.ModeVariable, "daemon");
+        var path = Path.Combine(_directory, "daemon.docx");
+
+        var created = Parse(WordFileTool.File(WordFileAction.Create, path));
+        Assert.True(created.GetProperty("success").GetBoolean(), created.ToString());
+        var session = created.GetProperty("sessionId").GetString()!;
+
+        try
+        {
+            var appended = Parse(WordTextTool.Text(WordTextAction.Append, session, text: "Aus dem Dienst."));
+            Assert.True(appended.GetProperty("success").GetBoolean(), appended.ToString());
+
+            var read = Parse(WordTextTool.Text(WordTextAction.Get, session));
+            Assert.Contains("Aus dem Dienst.", read.GetProperty("text").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            WordFileTool.File(WordFileAction.Close, session_id: session, save: false);
+            ServiceBridge.Invoke("service.shutdown");
+        }
+    }
+}

--- a/tests/WordMcp.McpServer.Tests/ServiceBridgeTests.cs
+++ b/tests/WordMcp.McpServer.Tests/ServiceBridgeTests.cs
@@ -192,10 +192,25 @@ public class ServiceBridgeTests
     }
 
     [Fact]
-    public void ABatchStillNeedsASessionId()
+    public void AToolCommandStillNeedsASessionId()
     {
-        var ex = Assert.Throws<ArgumentException>(() => WordToolsBase.Batch(null));
+        var json = WordTextTool.Text(WordTextAction.Get, session_id: string.Empty);
+        using var document = JsonDocument.Parse(json);
 
-        Assert.Contains("session_id", ex.Message, StringComparison.Ordinal);
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.Contains(
+            "session_id",
+            document.RootElement.GetProperty("errorMessage").GetString(),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AToolCommandReportsAnUnknownSession()
+    {
+        var json = WordTextTool.Text(WordTextAction.Get, session_id: "word-doesnotexist");
+        using var document = JsonDocument.Parse(json);
+
+        Assert.False(document.RootElement.GetProperty("success").GetBoolean());
+        Assert.Equal("KeyNotFoundException", document.RootElement.GetProperty("errorType").GetString());
     }
 }

--- a/tests/WordMcp.McpServer.Tests/WordToolsBaseTests.cs
+++ b/tests/WordMcp.McpServer.Tests/WordToolsBaseTests.cs
@@ -51,20 +51,6 @@ public class WordToolsBaseTests
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void Batch_RequiresSessionId(string? sessionId)
-    {
-        var ex = Assert.Throws<ArgumentException>(() => WordToolsBase.Batch(sessionId));
-        Assert.Contains("session_id", ex.Message, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void Batch_ReportsUnknownSessionId()
-        => Assert.Throws<KeyNotFoundException>(() => WordToolsBase.Batch("word-doesnotexist"));
-
-    [Theory]
     [InlineData("report.docx")]
     [InlineData(@"..\report.docx")]
     [InlineData(@"docs\report.docx")]


### PR DESCRIPTION
Schließt den letzten offenen Rest von Epic #5.

## Das Problem

Die Tools wurden nur auf einer Seite der Naht generiert. Jedes von ihnen besorgte sich zuerst ein `IWordBatch` — ein lebendes COM-Handle, das die Prozessgrenze nicht überqueren kann. Der Daemon konnte also Sessions halten, die kein Tool erreichte.

## Was sich ändert

Der Generator emittiert jetzt **beide Hälften aus derselben Beschreibung**:

* im `WordMcp.McpServer` das Tool, das seine Parameter unter ihren Wire-Namen verpackt und `kategorie.aktion` an die `ServiceBridge` gibt,
* im `WordMcp.Service` den Dispatcher, der sie wieder auspackt, dieselben Defaults anwendet, dieselben Fehlermeldungen wirft und das Kommando ruft.

Er wählt seine Hälfte am Assembly-Namen und ist in beiden Projekten als Analyzer eingebunden. Die Implementierung findet er über die Klasse, die das Interface implementiert — eine neue Kategorie braucht nirgends einen Registry-Eintrag. Damit entfällt auch die `WordServices`-Property-Tabelle, auf die der Generator bisher angewiesen war.

Der im Issue-Text vorgeschlagene Umbau auf vier Projekte war dafür nicht nötig: `WordMcp.Service` referenziert zusätzlich Core, die Richtung bleibt zyklenfrei.

## Zwei Bugs, die erst der echte Daemon zeigte

**`office.dll` fehlt zur Laufzeit.** Word wird durchgehend über `dynamic` gesteuert, und der Binder braucht die Interop-Assembly, um ein Mitglied zu binden. Die Datei liegt in jedem bin-Verzeichnis, steht aber in keiner `deps.json`. Ein Test-Host probt sein eigenes Verzeichnis und verdeckt das; eine normale EXE nicht — der Daemon konnte kein einziges Dokument öffnen. Das betraf latent auch `WordMcp.McpServer.exe` in Produktion.

**Ein Fehler beim COM-Aufräumen beendete den Prozess.** Er lief auf dem STA-Thread, wo ihn niemand fängt, und hätte im Dienst alle anderen Sessions mitgerissen. Aufräumen schluckt und protokolliert jetzt — nachdem der eigentliche Fehler den Aufrufer längst erreicht hat.

## Nebenbei

Die Session wird erst aufgelöst, wenn der Dispatcher das Kommando kennt. Ein vertipptes Kommando meldet sich dadurch als unbekannt, statt über eine `session_id` zu klagen, die der Aufrufer nie hätte angeben müssen.

## Tests

582 grün, darunter drei neue Word-Integrationstests: Text über ein generiertes Tool geschrieben und über ein anderes zurückgelesen, ein fehlendes Argument noch immer so benannt wie der Aufrufer es tippte, und dasselbe Tool, das ein Dokument über den Daemon durch die Pipe bearbeitet.

Refs #49, closes #5
