### PR TITLE
fix: bring the registry manifest up to the current schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,9 @@ jobs:
           -p:Version=${{ steps.version.outputs.version }}
           --output ${{ github.workspace }}/artifacts
 
-      # The MCP registry rejects a server.json whose version disagrees with the package, and that
-      # only surfaces after publishing - so it is checked while the package is still local.
+      # The MCP registry rejects a server.json whose version disagrees with the package, and it
+      # verifies package ownership through an mcp-name marker in the packaged readme. Both only
+      # surface after publishing, so they are checked while the package is still local.
       - name: Verify packaged server.json
         shell: pwsh
         run: |
@@ -104,6 +105,12 @@ jobs:
 
             $reader = New-Object System.IO.StreamReader($entry.Open())
             $json = $reader.ReadToEnd() | ConvertFrom-Json
+
+            $readmeEntry = $zip.Entries | Where-Object { $_.FullName -eq 'README.md' }
+            if (-not $readmeEntry) { throw "The package does not contain README.md." }
+
+            $readmeReader = New-Object System.IO.StreamReader($readmeEntry.Open())
+            $readme = $readmeReader.ReadToEnd()
           } finally {
             $zip.Dispose()
           }
@@ -115,7 +122,12 @@ jobs:
             throw "server.json package entry says $($json.packages[0].version) but the package is $expected."
           }
 
-          Write-Host "server.json matches $expected."
+          # The marker must be followed by a boundary, or the registry does not match it.
+          if ($readme -notmatch "mcp-name:\s*$([regex]::Escape($json.name))(\s|-->|$)") {
+            throw "The readme does not carry 'mcp-name: $($json.name)', so the registry cannot verify ownership."
+          }
+
+          Write-Host "server.json matches $expected and the readme claims $($json.name)."
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # WordMcp — Microsoft Word MCP Server
 
+<!-- mcp-name: io.github.trsdn/mcp-server-word -->
+
 An [MCP](https://modelcontextprotocol.io) server that lets AI assistants drive **Microsoft Word for Windows** through COM automation: open documents, read and edit text, manage paragraphs and tables, set document properties and export to PDF.
 
 > **Windows only.** A local installation of Microsoft Word is required — this server automates the real application, it does not parse `.docx` files.

--- a/src/WordMcp.McpServer/.mcp/server.json
+++ b/src/WordMcp.McpServer/.mcp/server.json
@@ -1,10 +1,12 @@
 {
-  "$schema": "https://modelcontextprotocol.io/schemas/draft/2025-07-09/server.json",
-  "description": "Microsoft Word automation for AI assistants. Requires Word for Windows.",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.trsdn/mcp-server-word",
+  "title": "Word",
+  "description": "Microsoft Word automation for AI assistants. Requires Word for Windows.",
+  "version": "0.1.0",
   "packages": [
     {
-      "registry_type": "nuget",
+      "registryType": "nuget",
       "identifier": "WordMcp.McpServer",
       "version": "0.1.0",
       "transport": {
@@ -15,6 +17,5 @@
   "repository": {
     "url": "https://github.com/trsdn/mcp-server-word",
     "source": "github"
-  },
-  "version": "0.1.0"
+  }
 }


### PR DESCRIPTION
Vorarbeit zu #51 — die beiden Dinge, die keine Zugangsdaten brauchen.

## Das Manifest wäre abgelehnt worden

`.mcp/server.json` sprach noch den Entwurf `2025-07-09`. Seit dem Schema vom 2025-09-16 erwartet die Registry camelCase, `registry_type` erfüllt also das Pflichtfeld `registryType` nicht mehr. Gegen das aktuelle Schema geprüft:

```
alt:  INVALID: 'registryType' is a required property
neu:  VALID
```

Aufgefallen wäre das beim ersten Veröffentlichungsversuch, nicht vorher.

## Der Paket-Eigentümer war nicht nachweisbar

Die Registry belegt den Besitz eines NuGet-Pakets über einen `mcp-name: <servername>`-Marker in der paketierten README. Es gab keinen, das Paket hätte also als nicht beansprucht gegolten. Der Marker steht jetzt in der README, in einem Kommentar auf eigener Zeile — hinter dem Token muss eine Grenze folgen, sonst greift der Abgleich nicht.

## Und ein Test dafür

Die Release-Pipeline prüfte bereits die Version im gepackten Nupkg, weil eine Abweichung erst nach dem Veröffentlichen auffällt. Der Marker versagt genauso spät, also wird er an derselben Stelle geprüft — gegen die README **im Paket**, nicht die im Repo.

Lokal verifiziert: gepackt, Prüfung durchlaufen, Manifest gegen `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` validiert.

Damit bleiben in #51 nur noch die Schritte übrig, die eine Anmeldung als `trsdn` verlangen.
