### PR TITLE
ci: publish to NuGet through trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
 
     permissions:
       contents: write
+      # Trusted publishing exchanges this token for a short-lived NuGet key.
+      id-token: write
 
     steps:
       - name: Checkout
@@ -135,14 +137,24 @@ jobs:
           name: nuget-package
           path: ${{ github.workspace }}/artifacts/*.nupkg
 
+      # Trusted publishing over OIDC rather than a stored key: NuGet keys issued from
+      # 2026-08-17 expire after 30 days, so a secret here would quietly rot between releases.
+      # The policy on nuget.org names this repository and this workflow file.
+      - name: Log in to NuGet
+        id: nuget-login
+        if: steps.version.outputs.publish == 'true'
+        uses: NuGet/login@v1
+        with:
+          user: ${{ vars.NUGET_USER }}
+
       - name: Push to NuGet
         if: steps.version.outputs.publish == 'true'
         shell: pwsh
         env:
-          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
         run: |
           if (-not $env:NUGET_API_KEY) {
-            throw "The NUGET_API_KEY repository secret is not set, so this release cannot be published."
+            throw "Trusted publishing returned no key. Check the NUGET_USER repository variable and the trusted publishing policy on nuget.org."
           }
 
           dotnet nuget push "${{ github.workspace }}/artifacts/*.nupkg" `


### PR DESCRIPTION
Ein gespeicherter API-Key hätte sofort zu verrotten begonnen: Keys, die ab dem 17.08.2026 erzeugt werden, laufen nach 30 Tagen ab. Das erste Release hätte funktioniert und irgendein späteres wäre aus einem Grund gescheitert, an den sich niemand mehr erinnert.

Der Workflow tauscht jetzt das eigene OIDC-Token gegen einen kurzlebigen Schlüssel zum Zeitpunkt der Veröffentlichung. Nichts Dauerhaftes wird gespeichert, und die Richtlinie auf nuget.org benennt dieses Repository und diese Workflow-Datei — ein Schlüssel ist von woanders nicht verwendbar.

Der Benutzername ist eine Repository-Variable statt eines Secrets, weil er keines ist. Dass er nicht in der Datei steht, heißt außerdem: ein falscher Wert lässt sich ohne Commit korrigieren.

Refs #51