### PR TITLE
ci: publish to the MCP registry from the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,3 +181,57 @@ jobs:
 
           gh @arguments
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      # The registry downloads the package to check the mcp-name marker in its readme, so it has
+      # to wait for nuget.org to finish indexing - which takes minutes, not seconds, after a push.
+      - name: Wait for nuget.org to index the package
+        if: steps.version.outputs.publish == 'true'
+        shell: pwsh
+        run: |
+          $version = '${{ steps.version.outputs.version }}'
+          $url = 'https://api.nuget.org/v3-flatcontainer/wordmcp.mcpserver/index.json'
+
+          foreach ($attempt in 1..30) {
+            try {
+              $versions = (Invoke-RestMethod $url -TimeoutSec 30).versions
+              if ($versions -contains $version) {
+                Write-Host "$version is indexed."
+                exit 0
+              }
+              Write-Host "Attempt ${attempt}: $version is not indexed yet."
+            } catch {
+              Write-Host "Attempt ${attempt}: the package is not listed yet."
+            }
+            Start-Sleep -Seconds 20
+          }
+
+          throw "nuget.org did not index $version within ten minutes, so the registry would reject it."
+
+      - name: Install mcp-publisher
+        if: steps.version.outputs.publish == 'true'
+        shell: pwsh
+        run: |
+          # Always the latest: an outdated publisher fails against the registry with 'invalid audience'.
+          $release = Invoke-RestMethod 'https://api.github.com/repos/modelcontextprotocol/registry/releases/latest'
+          $asset = $release.assets | Where-Object { $_.name -eq 'mcp-publisher_windows_amd64.tar.gz' }
+          if (-not $asset) { throw "The release $($release.tag_name) has no Windows build of mcp-publisher." }
+
+          Invoke-WebRequest $asset.browser_download_url -OutFile mcp-publisher.tar.gz
+          tar -xzf mcp-publisher.tar.gz mcp-publisher.exe
+          ./mcp-publisher.exe --version
+
+      # OIDC again, so nothing durable is stored for the registry either. The namespace
+      # io.github.trsdn is granted because the workflow runs in a repository owned by trsdn.
+      - name: Publish to the MCP registry
+        if: steps.version.outputs.publish == 'true'
+        shell: pwsh
+        run: |
+          # The checked-in manifest is a template; this is the copy stamped with the real version,
+          # and the same one that went into the package.
+          $manifest = 'src/WordMcp.McpServer/obj/mcp/server.json'
+
+          ./mcp-publisher.exe login github-oidc
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+          ./mcp-publisher.exe publish $manifest
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/src/WordMcp.McpServer/WordMcp.McpServer.csproj
+++ b/src/WordMcp.McpServer/WordMcp.McpServer.csproj
@@ -40,12 +40,13 @@
 
   <!-- The MCP registry rejects a server.json whose version disagrees with the package version, so
        the checked-in file is treated as a template and the version is stamped in at build time
-       from $(Version). Both occurrences are replaced: the server version and the package version. -->
+       from $(Version). Both occurrences are replaced: the server version and the package version.
+       The target is deliberately not incremental: its real input is $(Version), not the template,
+       so a file timestamp comparison would happily leave yesterday's version in place. Writing is
+       still conditional, so an unchanged version does not touch the file. -->
   <Target Name="_StampMcpServerJsonVersion"
           BeforeTargets="AssignTargetPaths;GenerateNuspec"
-          Condition="Exists('$(MSBuildProjectDirectory)\.mcp\server.json')"
-          Inputs="$(MSBuildProjectDirectory)\.mcp\server.json"
-          Outputs="$(BaseIntermediateOutputPath)mcp\server.json">
+          Condition="Exists('$(MSBuildProjectDirectory)\.mcp\server.json')">
     <PropertyGroup>
       <_McpServerJsonText>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\.mcp\server.json'))</_McpServerJsonText>
       <_McpServerJsonText>$([System.Text.RegularExpressions.Regex]::Replace($(_McpServerJsonText), '"version": "[^"]*"', '"version": "$(Version)"'))</_McpServerJsonText>


### PR DESCRIPTION
Die Registry akzeptiert dasselbe OIDC-Token, das der Workflow ohnehin hat. Der Eintrag braucht also weder ein gespeichertes Zugangsmittel noch einen Handgriff. Den Namensraum `io.github.trsdn` bekommt er, weil der Workflow in einem Repository läuft, das `trsdn` gehört.

Die Reihenfolge ist nicht beliebig: die Registry lädt das Paket herunter, um den `mcp-name`-Marker in der README zu finden. Das geht erst, wenn nuget.org fertig indiziert hat — Minuten nach dem Push, nicht Sekunden. Der Workflow wartet darauf, dass die Version auftaucht, statt eine Schlafdauer zu raten.

Das Publisher-Binary wird absichtlich in der neuesten Fassung geholt. Ein veraltetes scheitert an der Registry mit `invalid audience`, was wie ein Konfigurationsfehler aussieht und keiner ist.

## Nebenbei ein echter Fehler

Das Stempeln der Version verglich Dateizeitstempel, obwohl seine tatsächliche Eingabe die Version ist und nicht die Vorlage. Ein Build von 0.2.0 über einem Baum, der 0.1.0 gebaut hatte, ließ die alte Version im Manifest stehen — der frische Checkout in CI verdeckte das, ein zweiter lokaler Build nicht.

Vorher, nach `dotnet build -p:Version=0.2.0`:

```
"version": "0.1.0"
```

Jetzt ergibt 0.2.0 dann 0.1.0 auch 0.2.0 dann 0.1.0.

## Verifiziert

* `mcp-publisher validate` gegen das gestempelte Manifest: gültig
* Workflow-YAML geparst, Schritte und Berechtigungen geprüft
* Stempeln vorwärts und rückwärts durchgespielt

Refs #51
