### PR TITLE
fix(ci): resolve the package path before pushing to NuGet

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,11 +157,19 @@ jobs:
             throw "Trusted publishing returned no key. Check the NUGET_USER repository variable and the trusted publishing policy on nuget.org."
           }
 
-          dotnet nuget push "${{ github.workspace }}/artifacts/*.nupkg" `
-            --source https://api.nuget.org/v3/index.json `
-            --api-key $env:NUGET_API_KEY `
-            --skip-duplicate
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          # `dotnet nuget push` does not expand the wildcard in a mixed-separator path such as
+          # `D:\a\repo\repo/artifacts/*.nupkg`; it reports "File does not exist". Resolving the
+          # package here keeps the push independent of that behaviour.
+          $packages = @(Get-ChildItem "${{ github.workspace }}/artifacts/*.nupkg")
+          if ($packages.Count -eq 0) { throw "No package found in ${{ github.workspace }}/artifacts." }
+
+          foreach ($package in $packages) {
+            dotnet nuget push $package.FullName `
+              --source https://api.nuget.org/v3/index.json `
+              --api-key $env:NUGET_API_KEY `
+              --skip-duplicate
+            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          }
 
       - name: Create GitHub release
         if: steps.version.outputs.publish == 'true'


### PR DESCRIPTION
Der erste Release-Lauf für `v0.1.0` kam bis `Push to NuGet` und brach dort ab:

```
error: File does not exist (D:\a\mcp-server-word\mcp-server-word/artifacts/*.nupkg).
```

Das Paket lag sehr wohl dort — der unmittelbar davor laufende Schritt `Verify packaged server.json` hatte es geöffnet und geprüft. Die Ursache ist `dotnet nuget push`: es löst den Platzhalter in einem Pfad mit gemischten Trennzeichen nicht auf. `${{ github.workspace }}` liefert `D:\a\...` mit Backslashes, der angehängte Teil `/artifacts/*.nupkg` verwendet Schrägstriche, und das Ergebnis wird als Dateiname genommen statt als Muster.

Lokal reproduziert, mit einem Ordner als Quelle:

| Aufruf | Ergebnis |
| --- | --- |
| `dotnet nuget push "C:\...\pushglob/artifacts/*.nupkg"` | `error: Die Datei ist nicht vorhanden (...)` |
| `Get-ChildItem` vorher, dann `push $p.FullName` | `Ihr Paket wurde per Push übertragen.` |

Der Schritt löst das Paket jetzt über `Get-ChildItem` auf und übergibt den vollen Pfad — genau so, wie es `Create GitHub release` schon seit jeher tut, samt Kommentar an derselben Stelle. Fehlt das Paket, bricht der Schritt mit einer Meldung ab, die den Ordner nennt, statt eine leere Schleife durchzulaufen.

Was der Lauf nebenbei gezeigt hat: `Log in to NuGet` war grün. Trusted Publishing über OIDC greift, die Richtlinie auf nuget.org passt, und es wurde ein Schlüssel ausgegeben. Der Rest des Pfades ab `Create GitHub release` ist weiterhin ungetestet.

Getestet: `release.yml` geparst (15 Schritte), Glob-Verhalten wie oben lokal gegen einen Ordner-Feed gegenübergestellt.
