### PR TITLE
docs: document running the server from the MCP registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,22 @@ dotnet pack src\WordMcp.McpServer\WordMcp.McpServer.csproj -c Release -o artifac
 dotnet tool install --global --add-source .\artifacts WordMcp.McpServer
 ```
 
+### Without installing
+
+The server is listed in the [MCP registry](https://registry.modelcontextprotocol.io/v0/servers?search=mcp-server-word) as `io.github.trsdn/mcp-server-word`. Clients that resolve packages themselves can run it through `dnx`, which fetches the version on demand instead of keeping a global tool around:
+
+```json
+{
+  "servers": {
+    "word": {
+      "type": "stdio",
+      "command": "dnx",
+      "args": ["WordMcp.McpServer@0.1.0", "--yes"]
+    }
+  }
+}
+```
+
 ## Client configuration
 
 The server speaks **stdio**.


### PR DESCRIPTION
`v0.1.0` ist veröffentlicht: [WordMcp.McpServer auf nuget.org](https://www.nuget.org/packages/WordMcp.McpServer) und `io.github.trsdn/mcp-server-word` in der MCP-Registry, dort mit Status `active`.

Damit lässt sich der Server auch ohne globale Installation starten. Die Registry führt das NuGet-Paket, und `dnx` holt die angeforderte Version bei Bedarf — für Clients, die Pakete selbst auflösen, ist das der kürzere Weg als `dotnet tool install`. Genau dieser Ausschnitt steht auch auf der Paketseite auf nuget.org.

Der `mcp-name`-Marker in Zeile 3 bleibt unangetastet; über ihn verifiziert die Registry den Paketbesitz.
