### PR TITLE
ci: verify the published package installs and starts

### DIFF
--- a/.github/smoke-test.ps1
+++ b/.github/smoke-test.ps1
@@ -1,0 +1,80 @@
+param(
+    [Parameter(Mandatory = $true)][string]$Command,
+    [string[]]$CommandArgs = @()
+)
+
+# Drives a stdio MCP server through initialize + tools/list and prints the tool names.
+# Used as a release smoke test: it proves the published package starts and advertises
+# its tools. It deliberately calls no tool, so it needs no Word installation.
+
+$ErrorActionPreference = 'Stop'
+
+$psi = [System.Diagnostics.ProcessStartInfo]::new()
+$psi.FileName = $Command
+foreach ($a in $CommandArgs) { $psi.ArgumentList.Add($a) }
+$psi.RedirectStandardInput = $true
+$psi.RedirectStandardOutput = $true
+$psi.RedirectStandardError = $true
+$psi.UseShellExecute = $false
+
+$proc = [System.Diagnostics.Process]::Start($psi)
+
+function Send-Message($obj) {
+    $json = $obj | ConvertTo-Json -Depth 10 -Compress
+    $proc.StandardInput.WriteLine($json)
+    $proc.StandardInput.Flush()
+}
+
+function Receive-Message([int]$id, [int]$timeoutSeconds = 60) {
+    $deadline = (Get-Date).AddSeconds($timeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        $readTask = $proc.StandardOutput.ReadLineAsync()
+        if (-not $readTask.Wait([int]($deadline - (Get-Date)).TotalMilliseconds)) { break }
+
+        $line = $readTask.Result
+        if ($null -eq $line) { throw "The server closed stdout before answering request $id." }
+        if ([string]::IsNullOrWhiteSpace($line)) { continue }
+
+        $message = $null
+        try { $message = $line | ConvertFrom-Json } catch { continue }
+        if ($message.id -eq $id) { return $message }
+    }
+    throw "No answer to request $id within $timeoutSeconds seconds."
+}
+
+try {
+    Send-Message @{
+        jsonrpc = '2.0'
+        id      = 1
+        method  = 'initialize'
+        params  = @{
+            protocolVersion = '2024-11-05'
+            capabilities    = @{}
+            clientInfo      = @{ name = 'smoke-test'; version = '1.0.0' }
+        }
+    }
+
+    $init = Receive-Message -id 1
+    if ($init.error) { throw "initialize failed: $($init.error | ConvertTo-Json -Compress)" }
+    Write-Host "initialize: $($init.result.serverInfo.name) $($init.result.serverInfo.version)"
+
+    Send-Message @{ jsonrpc = '2.0'; method = 'notifications/initialized' }
+
+    Send-Message @{ jsonrpc = '2.0'; id = 2; method = 'tools/list' }
+    $list = Receive-Message -id 2
+    if ($list.error) { throw "tools/list failed: $($list.error | ConvertTo-Json -Compress)" }
+
+    $tools = @($list.result.tools | ForEach-Object { $_.name } | Sort-Object)
+    if ($tools.Count -eq 0) { throw "The server advertises no tools." }
+
+    Write-Host "tools ($($tools.Count)): $($tools -join ', ')"
+    exit 0
+}
+finally {
+    if (-not $proc.HasExited) {
+        try { $proc.StandardInput.Close() } catch { }
+        if (-not $proc.WaitForExit(5000)) { $proc.Kill($true) }
+    }
+    $stderr = $proc.StandardError.ReadToEnd()
+    if ($stderr) { Write-Host "--- server stderr ---`n$stderr" }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,3 +74,38 @@ jobs:
         with:
           name: nuget-package
           path: ${{ github.workspace }}/artifacts/*.nupkg
+
+      # Packing proves the package builds, not that it works. A broken tool entry point,
+      # a renamed command or a file missing from the package only surfaces on install,
+      # and no unit test covers that.
+      - name: Install the packed tool
+        shell: pwsh
+        run: |
+          # Restricted to the local folder, so this cannot quietly install a same-numbered
+          # build from nuget.org instead of the one just packed.
+          $config = Join-Path "${{ runner.temp }}" 'local-only.config'
+          @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <clear />
+              <add key="local" value="${{ github.workspace }}/artifacts" />
+            </packageSources>
+          </configuration>
+          "@ | Set-Content -Path $config -Encoding UTF8
+
+          dotnet tool install WordMcp.McpServer `
+            --tool-path "${{ github.workspace }}/toolcheck" `
+            --configfile $config
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+      # The runner has no Word, so the handshake is the deepest check possible here:
+      # it starts the server and lists the tools without touching a document.
+      - name: Smoke test the packed tool
+        shell: pwsh
+        run: |
+          & "${{ github.workspace }}/toolcheck/mcp-word.exe" --version
+          if ($LASTEXITCODE -ne 0) { throw "mcp-word --version failed." }
+
+          pwsh -NoProfile -File .github/smoke-test.ps1 -Command "${{ github.workspace }}/toolcheck/mcp-word.exe"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,10 @@ jobs:
     name: Build, test and publish
     runs-on: windows-latest
 
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      publish: ${{ steps.version.outputs.publish }}
+
     permissions:
       contents: write
       # Trusted publishing exchanges this token for a short-lived NuGet key.
@@ -243,3 +247,14 @@ jobs:
 
           ./mcp-publisher.exe publish $manifest
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+  # Everything above tests the source tree and pushes an artefact. This installs that
+  # artefact back from nuget.org the way a user would, which is the only step that can
+  # tell whether the release is actually usable.
+  verify:
+    name: Verify the published package
+    needs: release
+    if: needs.release.outputs.publish == 'true'
+    uses: ./.github/workflows/verify-package.yml
+    with:
+      version: ${{ needs.release.outputs.version }}

--- a/.github/workflows/verify-package.yml
+++ b/.github/workflows/verify-package.yml
@@ -1,0 +1,74 @@
+name: Verify published package
+
+# Installs WordMcp.McpServer from nuget.org exactly as a user would and drives an MCP
+# handshake against it. Everything else in CI tests the source tree; this is the only
+# check that the artefact people actually download is installable and starts.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to verify, without the leading v (e.g. 0.1.0). Empty means the latest release."
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to verify, without the leading v."
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Install from nuget.org and start
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          global-json-file: global.json
+
+      # nuget.org needs a moment after a push before the version resolves, so this is
+      # retried rather than failed on the first miss.
+      - name: Install from nuget.org
+        shell: pwsh
+        run: |
+          $version = '${{ inputs.version }}'
+
+          $arguments = @(
+            'tool', 'install', 'WordMcp.McpServer',
+            '--tool-path', "${{ github.workspace }}/toolcheck",
+            '--source', 'https://api.nuget.org/v3/index.json'
+          )
+          if ($version) { $arguments += @('--version', $version) }
+
+          $attempts = 20
+          for ($i = 1; $i -le $attempts; $i++) {
+            dotnet @arguments
+            if ($LASTEXITCODE -eq 0) { break }
+
+            if ($i -eq $attempts) { throw "Could not install WordMcp.McpServer $version from nuget.org." }
+            Write-Host "Attempt $i failed, retrying in 20s."
+            Start-Sleep -Seconds 20
+          }
+
+      - name: Report the installed version
+        shell: pwsh
+        run: |
+          & "${{ github.workspace }}/toolcheck/mcp-word.exe" --version
+          if ($LASTEXITCODE -ne 0) { throw "mcp-word --version failed." }
+
+      # The runner has no Word, so the handshake is the deepest check possible here:
+      # it starts the server and lists the tools without touching a document.
+      - name: MCP handshake
+        shell: pwsh
+        run: |
+          pwsh -NoProfile -File .github/smoke-test.ps1 -Command "${{ github.workspace }}/toolcheck/mcp-word.exe"
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 artifacts/
 dist/
 
+# Scratch install target used by the CI smoke test.
+toolcheck/
+
 # Visual Studio / Rider / VS Code
 .vs/
 .idea/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,12 @@ publishing, and the release workflow checks for it in the packed readme to say s
 To rehearse the build without publishing, run the workflow manually from the Actions tab and pass a
 version; that path packs and uploads an artifact but never pushes.
 
+Once the push has gone through, a final job installs the package from nuget.org the way a user
+would and drives an MCP handshake against it. Everything before it tests the source tree, so this
+is the only step that can tell whether the artefact people actually download starts at all. The
+same check runs on every pull request against the freshly packed file, and it can be pointed at any
+released version from the Actions tab through **Verify published package**.
+
 ## Reporting bugs
 Use the [issue templates](https://github.com/trsdn/mcp-server-word/issues/new/choose). Include the
 Word build number and UI language; localization is behind a surprising share of the bugs here.


### PR DESCRIPTION
Bis jetzt prüft die CI ausschließlich den Quellbaum. Ob das Paket, das am Ende auf nuget.org landet, sich installieren lässt und überhaupt startet, hat nie jemand nachgesehen — obwohl genau das in der Definition of Done von #3 stand. Ein kaputter Einstiegspunkt, ein umbenannter Befehl oder eine Datei, die es nicht ins Paket geschafft hat, fällt in keinem Unit-Test auf.

Der neue `.github/smoke-test.ps1` fährt einen stdio-MCP-Server über `initialize` und `tools/list` und gibt die Werkzeugnamen aus. Er ruft bewusst kein Werkzeug auf, braucht also kein installiertes Word und läuft damit auf einem GitHub-Runner.

Verdrahtet ist er an zwei Stellen:

- **`build.yml`**, im `pack`-Job: das frisch gepackte Paket wird installiert und angefahren. Die Installation liest eine NuGet-Konfiguration mit `<clear />` und nur dem lokalen Ordner — sonst könnte `dotnet tool install` klammheimlich die gleichnamige Version von nuget.org ziehen statt der eben gebauten.
- **`verify-package.yml`**, neu: installiert von nuget.org, wie ein Nutzer es täte. Läuft am Ende jedes Releases über `workflow_call` und lässt sich aus dem Actions-Tab gegen jede veröffentlichte Version starten.

Lokal durchgespielt, mit dem echten Paket:

```
Word MCP Server v0.1.0.0
initialize: word-mcp 0.1.0.0
tools (15): bookmark, comment, document, field, file, header-footer, image,
            list, paragraph, revision, screenshot, section, style, table, text
```

Und gegengeprüft, dass der Test nicht hohl ist: gegen `cmd /c exit` bricht er ab, weil stdout schließt, bevor eine Antwort kommt; gegen einen Prozess, der nie antwortet, läuft er in die Zeitüberschreitung. Beide Male Exit-Code 1.

Getestet: `pack` → `dotnet tool install --tool-path --configfile` → `mcp-word --version` → Handshake, alles lokal durchlaufen; die drei Workflows geparst.
