### PR TITLE
Add footnote and content control tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ itself, which is what a single client wants: no second process and no startup wa
 
 ## Tools
 
-Fifteen tools, each with an `action` parameter.
+Seventeen tools, each with an `action` parameter.
 
 ### `file` — session lifecycle
 
@@ -341,6 +341,56 @@ bookmark(action: "get-text", session_id: "...", name: "Intro")
 
 ---
 
+### `footnote` — footnotes and endnotes
+
+| Action | Purpose |
+|---|---|
+| `list` | Footnotes or endnotes with index, reference mark, paragraph and text |
+| `add` | Attach a note to a paragraph, or to a phrase inside it |
+| `set-text` | Rewrite the text of a note |
+| `delete` | Remove a note together with its reference mark |
+
+`kind` selects `footnote` (default) or `endnote`; the two are separate collections in Word with
+independent numbering. This is the only way to reach footnote text at all — `text(get)` returns the
+body story and never the notes.
+
+```jsonc
+footnote(action: "list", session_id: "...")
+footnote(action: "add", session_id: "...", paragraph_index: 4,
+         text: "Annual report 2025, p. 14.", anchor_text: "fifteen percent")
+footnote(action: "add", session_id: "...", paragraph_index: 4,
+         text: "Method described in appendix B.", kind: "endnote")
+```
+
+---
+
+### `content-control` — template fields
+
+| Action | Purpose |
+|---|---|
+| `list` | Content controls with tag, title, type, lock state and current text |
+| `get` | Read the controls addressed by `tag` or `id` |
+| `set-text` | Fill them; `is_checked` for checkbox controls |
+| `add` | Wrap a paragraph in a new control |
+| `delete` | Remove controls, optionally with their contents |
+
+Content controls are the structured fields a Word template exposes. Filling them is the reliable way
+to complete a template — `text(replace)` on the surrounding text destroys the control and its
+binding. `tag` is not unique and updates every match, which is what a template repeating a field
+expects; `id` addresses exactly one control.
+
+```jsonc
+content-control(action: "list", session_id: "...")
+content-control(action: "set-text", session_id: "...",
+                tag: "CustomerName", text: "Contoso Ltd")
+content-control(action: "set-text", session_id: "...",
+                tag: "TermsAccepted", is_checked: true)
+content-control(action: "delete", session_id: "...", tag: "Draft",
+                delete_contents: true)
+```
+
+---
+
 ### `screenshot` — see the page
 
 | Action | Purpose |
@@ -408,6 +458,12 @@ Every tool returns JSON. Failures are reported as structured payloads, never as 
 * **Bookmark names are restricted by Word.** They must start with a letter, may contain only letters, digits and underscores, and are limited to 40 characters. Spaces, hyphens, dots and non-ASCII letters are rejected before the call reaches Word, which would otherwise fail with a generic COM error.
 * **Bookmarks are the stable way to refer to a passage.** Paragraph indexes shift with every insertion, bookmarks do not. Bookmark a passage once and use `bookmark(get-text)` to re-read it later.
 * **`bookmark(add)` on a paragraph excludes the paragraph mark**, so `get-text` returns the text without a trailing newline. A bookmark over several paragraphs keeps the marks in between.
+* **`text(get)` never returns footnotes.** Footnotes and endnotes live in their own Word story, so a document that carries its sources in notes looks complete while a part of its content is missing. Call `footnote(list)` before summarizing or translating anything.
+* **Deleting a note renumbers the rest.** `footnote(delete)` shifts every following index down, the same trap as with comments and revisions. When removing several notes, work from the highest index downwards.
+* **Footnotes and endnotes are separate collections.** They have independent numbering, and every `footnote` action defaults to footnotes — pass `kind: "endnote"` explicitly.
+* **Filling a template means `content-control(set-text)`, not `text(replace)`.** Replacing the text around a content control destroys the control and its data binding; writing through the control keeps both.
+* **Content control tags are not unique.** `content-control(set-text)` by `tag` updates every match and reports how many, because a template that shows the customer name in the header and again in the signature block relies on exactly that. Use `id` when precisely one control is meant.
+* **`content-control(delete)` keeps the text by default.** Only `delete_contents: true` removes the content along with the control. Controls locked against deletion are reported instead of silently skipped.
 * **`screenshot(page)` renders through a PDF.** Word has no API that returns a page as an image, so the server exports the single page with `ExportAsFixedFormat` and rasterizes it. Unsaved changes are included, and the temporary PDF is deleted afterwards.
 * **Page numbers come from a fresh repagination.** A document that was only ever edited through automation reports a stale page count, so `screenshot` repaginates first. That also means the page count reflects the current layout, not the one at open time.
 

--- a/skills/word-mcp/SKILL.md
+++ b/skills/word-mcp/SKILL.md
@@ -3,15 +3,15 @@ name: word-mcp
 description: >
   Automate Microsoft Word on Windows through the WordMcp MCP server. Use when creating, reading,
   or editing Word documents: text, paragraphs, tables, images, styles, lists, sections, headers
-  and footers, fields and tables of contents, comments, tracked changes and bookmarks. Can render
-  a page as an image to check layout.
-  Triggers: Word, document, docx, report, letter, memo, table of contents, tracked changes,
-  comments, bookmarks, headers, footers.
+  and footers, fields and tables of contents, comments, tracked changes, bookmarks, footnotes and
+  content controls. Can render a page as an image to check layout.
+  Triggers: Word, document, docx, report, letter, memo, template, table of contents, tracked
+  changes, comments, bookmarks, footnotes, endnotes, content controls, headers, footers.
 ---
 
 # Word MCP Server Skill
 
-Fifteen tools, each taking an `action` parameter. The tool descriptions are complete; this file
+Seventeen tools, each taking an `action` parameter. The tool descriptions are complete; this file
 covers the workflow, the ordering rules that are not obvious, and the places where Word behaves
 in a way nobody would guess.
 
@@ -112,6 +112,9 @@ just fills the context window.
 - `field(update-all)` and `revision(accept|reject)` without an index deliberately walk headers and
   footers too; Word's own document-wide calls cover the body only.
 - `image` covers inline pictures only. Text boxes, floating shapes and charts are invisible to it.
+- `text(get)` returns the body story only — **footnotes and endnotes are never in it**. A document
+  that carries its sources in notes looks complete while it is not. Run `footnote(list)` before
+  summarizing or translating.
 - Headers are inherited between sections until something is written to them. `header-footer(set)`
   with a `section_index` breaks that link for you.
 - `first-page` and `even-pages` headers only render once the section switch is on, which
@@ -124,6 +127,13 @@ just fills the context window.
 - `comment(resolve)` usually fails on Microsoft 365: comments added through the API are unposted
   drafts and a draft cannot be marked done. Delete the comment instead.
 - `table(read)` returns merged cells as empty strings.
+- Filling a template means `content-control(set-text)`, never `text(replace)` — replacing the text
+  around a content control destroys the control and its binding. `content-control(list)` first, the
+  tags are what you address. A tag may occur several times on purpose and `set-text` fills every
+  match; use `id` when exactly one is meant.
+- `footnote(delete)` renumbers the notes after it, like comments and revisions. Delete from the
+  back. Footnotes and endnotes are separate collections with independent numbering; every action
+  defaults to `kind: "footnote"`.
 - Bookmark names must start with a letter and contain only letters, digits and underscores.
 - Styles are addressed in English (`Heading 1`) but Word reports them localized. `style(list)`
   returns both `name` and `english_name` — send `english_name` back when it is there.

--- a/src/WordMcp.ComInterop/ComInteropConstants.cs
+++ b/src/WordMcp.ComInterop/ComInteropConstants.cs
@@ -326,6 +326,40 @@ public static class ComInteropConstants
 
     #endregion
 
+    #region Content controls
+
+    /// <summary>WdContentControlType.wdContentControlRichText = 0.</summary>
+    public const int WdContentControlRichText = 0;
+
+    /// <summary>WdContentControlType.wdContentControlText = 1.</summary>
+    public const int WdContentControlText = 1;
+
+    /// <summary>WdContentControlType.wdContentControlPicture = 2.</summary>
+    public const int WdContentControlPicture = 2;
+
+    /// <summary>WdContentControlType.wdContentControlComboBox = 3.</summary>
+    public const int WdContentControlComboBox = 3;
+
+    /// <summary>WdContentControlType.wdContentControlDropdownList = 4.</summary>
+    public const int WdContentControlDropdownList = 4;
+
+    /// <summary>WdContentControlType.wdContentControlBuildingBlockGallery = 5.</summary>
+    public const int WdContentControlBuildingBlockGallery = 5;
+
+    /// <summary>WdContentControlType.wdContentControlDate = 6.</summary>
+    public const int WdContentControlDate = 6;
+
+    /// <summary>WdContentControlType.wdContentControlGroup = 7.</summary>
+    public const int WdContentControlGroup = 7;
+
+    /// <summary>WdContentControlType.wdContentControlCheckBox = 8.</summary>
+    public const int WdContentControlCheckBox = 8;
+
+    /// <summary>WdContentControlType.wdContentControlRepeatingSection = 9.</summary>
+    public const int WdContentControlRepeatingSection = 9;
+
+    #endregion
+
     #region Supported extensions
 
     /// <summary>

--- a/src/WordMcp.Core/Commands/ContentControl/ContentControlCommands.cs
+++ b/src/WordMcp.Core/Commands/ContentControl/ContentControlCommands.cs
@@ -1,0 +1,343 @@
+using System.Runtime.InteropServices;
+using WordMcp.ComInterop;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.ContentControl;
+
+/// <summary>
+/// Word COM implementation of <see cref="IContentControlCommands"/>.
+/// </summary>
+public sealed class ContentControlCommands : IContentControlCommands
+{
+    /// <inheritdoc />
+    public ContentControlListResult List(IWordBatch batch, string? tag = null, int maxTextLength = 500)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxTextLength, 1);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic controls = doc.ContentControls;
+            int total = (int)controls.Count;
+
+            var list = new List<ContentControlInfo>();
+
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                var info = Describe(controls[i], i, maxTextLength);
+
+                if (tag is null || string.Equals(info.Tag, tag, StringComparison.Ordinal))
+                    list.Add(info);
+            }
+
+            return new ContentControlListResult
+            {
+                TotalCount = list.Count,
+                Controls = list,
+                Message = tag is null
+                    ? $"Found {list.Count} content control(s)."
+                    : $"Found {list.Count} content control(s) tagged '{tag}' out of {total}."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ContentControlResult Get(
+        IWordBatch batch,
+        string? tag = null,
+        string? id = null,
+        int maxTextLength = 5000)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxTextLength, 1);
+        RequireSelector(tag, id);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            List<ControlMatch> matches = Match(doc, tag, id, maxTextLength);
+
+            return new ContentControlResult
+            {
+                Controls = matches.Select(m => m.Info).ToList(),
+                AffectedCount = matches.Count,
+                Message = $"Read {matches.Count} content control(s)."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ContentControlResult SetText(
+        IWordBatch batch,
+        string? text = null,
+        string? tag = null,
+        string? id = null,
+        bool? isChecked = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        RequireSelector(tag, id);
+
+        if (text is null && isChecked is null)
+        {
+            throw new ArgumentException(
+                "Provide text for a text control, or is_checked for a checkbox control.", nameof(text));
+        }
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            List<ControlMatch> matches = Match(doc, tag, id, 5000);
+            var updated = new List<ContentControlInfo>();
+
+            foreach (var match in matches)
+            {
+                ct.ThrowIfCancellationRequested();
+                dynamic control = match.Control;
+
+                if (match.Info.LockContents)
+                {
+                    throw new InvalidOperationException(
+                        $"Content control '{match.Info.Tag}' (id {match.Info.Id}) has locked contents. "
+                        + "Unlock it in Word before writing to it.");
+                }
+
+                int type = (int)control.Type;
+
+                if (type == ComInteropConstants.WdContentControlCheckBox)
+                {
+                    if (isChecked is null)
+                    {
+                        throw new ArgumentException(
+                            $"Content control '{match.Info.Tag}' is a checkbox; pass is_checked instead of text.",
+                            nameof(isChecked));
+                    }
+
+                    control.Checked = isChecked.Value;
+                }
+                else
+                {
+                    if (text is null)
+                    {
+                        throw new ArgumentException(
+                            $"Content control '{match.Info.Tag}' is a {match.Info.Type} control; pass text.",
+                            nameof(text));
+                    }
+
+                    SetControlText(control, type, text, match.Info);
+                }
+
+                updated.Add(Describe(control, match.Info.Index, 5000));
+            }
+
+            return new ContentControlResult
+            {
+                Controls = updated,
+                AffectedCount = updated.Count,
+                Message = updated.Count == 1
+                    ? "Updated 1 content control."
+                    : $"Updated {updated.Count} content controls."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ContentControlResult Add(
+        IWordBatch batch,
+        int paragraphIndex,
+        string type = "rich-text",
+        string? tag = null,
+        string? title = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(paragraphIndex, 1);
+
+        int wdType = WordConversions.ToWdContentControlType(type);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            int paragraphs = (int)doc.Paragraphs.Count;
+
+            if (paragraphIndex > paragraphs)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(paragraphIndex),
+                    $"Paragraph {paragraphIndex} does not exist. The document has {paragraphs} paragraph(s).");
+            }
+
+            dynamic paragraph = doc.Paragraphs[paragraphIndex].Range;
+
+            // A paragraph range ends after its mark; including it would make Word wrap the following
+            // paragraph as well.
+            int start = (int)paragraph.Start;
+            int end = Math.Max(start, (int)paragraph.End - 1);
+            dynamic range = doc.Range(start, end);
+
+            dynamic control = doc.ContentControls.Add(wdType, range);
+
+            if (!string.IsNullOrEmpty(tag))
+                control.Tag = tag;
+
+            if (!string.IsNullOrEmpty(title))
+                control.Title = title;
+
+            var info = Describe(control, (int)doc.ContentControls.Count, 5000);
+
+            return new ContentControlResult
+            {
+                Controls = [info],
+                AffectedCount = 1,
+                Message = $"Added a {info.Type} content control around paragraph {paragraphIndex}."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public ContentControlResult Delete(
+        IWordBatch batch,
+        string? tag = null,
+        string? id = null,
+        bool deleteContents = false)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        RequireSelector(tag, id);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            List<ControlMatch> matches = Match(doc, tag, id, 5000);
+
+            foreach (var match in matches)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                if (match.Info.LockContentControl)
+                {
+                    throw new InvalidOperationException(
+                        $"Content control '{match.Info.Tag}' (id {match.Info.Id}) is locked against "
+                        + "deletion. Unlock it in Word first.");
+                }
+
+                match.Control.Delete(deleteContents);
+            }
+
+            return new ContentControlResult
+            {
+                Controls = matches.Select(m => m.Info).ToList(),
+                AffectedCount = matches.Count,
+                Message = deleteContents
+                    ? $"Deleted {matches.Count} content control(s) and their contents."
+                    : $"Deleted {matches.Count} content control(s); their text stayed in the document."
+            };
+        });
+    }
+
+    private static void RequireSelector(string? tag, string? id)
+    {
+        if (string.IsNullOrWhiteSpace(tag) && string.IsNullOrWhiteSpace(id))
+        {
+            throw new ArgumentException(
+                "Provide either tag or id to address a content control. Call content-control(list) "
+                + "to see what the document offers.", nameof(tag));
+        }
+    }
+
+    /// <summary>
+    /// Resolves the controls a caller addressed. Tags are deliberately allowed to match several
+    /// controls, because templates repeat a field on purpose.
+    /// </summary>
+    private static List<ControlMatch> Match(dynamic doc, string? tag, string? id, int maxTextLength)
+    {
+        dynamic controls = doc.ContentControls;
+        int total = (int)controls.Count;
+        var matches = new List<ControlMatch>();
+
+        for (int i = 1; i <= total; i++)
+        {
+            dynamic control = controls[i];
+            var info = Describe(control, i, maxTextLength);
+
+            bool hit = id is not null
+                ? string.Equals(info.Id, id, StringComparison.OrdinalIgnoreCase)
+                : string.Equals(info.Tag, tag, StringComparison.Ordinal);
+
+            if (hit)
+                matches.Add(new ControlMatch(control, info));
+        }
+
+        if (matches.Count == 0)
+        {
+            string what = id is not null ? $"id '{id}'" : $"tag '{tag}'";
+            throw new ArgumentException(
+                $"No content control with {what} found. The document has {total} content control(s); "
+                + "call content-control(list) to see their tags.",
+                id is not null ? nameof(id) : nameof(tag));
+        }
+
+        return matches;
+    }
+
+    /// <summary>
+    /// Writes text into a control. Word rejects a direct assignment while the placeholder is showing
+    /// for some control types, so the range is cleared first.
+    /// </summary>
+    private static void SetControlText(dynamic control, int type, string text, ContentControlInfo info)
+    {
+        if (type is ComInteropConstants.WdContentControlPicture
+            or ComInteropConstants.WdContentControlGroup
+            or ComInteropConstants.WdContentControlRepeatingSection
+            or ComInteropConstants.WdContentControlBuildingBlockGallery)
+        {
+            throw new InvalidOperationException(
+                $"Content control '{info.Tag}' is a {info.Type} control and holds no plain text.");
+        }
+
+        try
+        {
+            control.Range.Text = text;
+        }
+        catch (COMException ex)
+        {
+            throw new InvalidOperationException(
+                $"Word refused to write into content control '{info.Tag}' ({info.Type}): {ex.Message}", ex);
+        }
+    }
+
+    private static ContentControlInfo Describe(dynamic control, int index, int maxTextLength)
+    {
+        int type = (int)control.Type;
+        string text = WordConversions.CleanRangeText((string?)control.Range.Text);
+
+        return new ContentControlInfo
+        {
+            Index = index,
+            Id = (string?)control.ID ?? string.Empty,
+            Tag = (string?)control.Tag ?? string.Empty,
+            Title = (string?)control.Title ?? string.Empty,
+            Type = WordConversions.FromWdContentControlType(type),
+            Text = text.Length > maxTextLength ? text[..maxTextLength] : text,
+            LockContents = (bool)control.LockContents,
+            LockContentControl = (bool)control.LockContentControl,
+            Checked = type == ComInteropConstants.WdContentControlCheckBox ? (bool)control.Checked : null,
+            ShowingPlaceholderText = ShowingPlaceholder(control)
+        };
+    }
+
+    private static bool ShowingPlaceholder(dynamic control)
+    {
+        try
+        {
+            return (bool)control.ShowingPlaceholderText;
+        }
+        catch (COMException)
+        {
+            return false;
+        }
+    }
+
+    private sealed record ControlMatch(dynamic Control, ContentControlInfo Info);
+}

--- a/src/WordMcp.Core/Commands/ContentControl/IContentControlCommands.cs
+++ b/src/WordMcp.Core/Commands/ContentControl/IContentControlCommands.cs
@@ -1,0 +1,102 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.ContentControl;
+
+/// <summary>
+/// Content control operations, the structured fields Word templates are built from.
+/// </summary>
+/// <remarks>
+/// A content control is addressed by its <c>tag</c> or by its Word <c>id</c>. Tags are not unique,
+/// and a template that repeats a field - a customer name in the header and again in the signature
+/// block - relies on that. So <c>set-text</c> by tag updates every match and reports how many, while
+/// <c>id</c> always addresses exactly one control.
+/// </remarks>
+[ServiceCategory("contentControl", "ContentControl")]
+[McpTool("content-control",
+    Title = "Content Control Operations",
+    Description = "Read and fill the content controls of a Word template. Content controls are the "
+        + "structured fields a template exposes - they carry a tag, a title and a type - and filling "
+        + "them is the reliable way to complete a template, because find-and-replace on the body "
+        + "text corrupts the control and loses the binding. "
+        + "content-control(list, session_id) shows every control with its tag, type and current "
+        + "text; start here, the tags are what you address afterwards. "
+        + "content-control(set-text, session_id, tag=\"CustomerName\", text=\"Contoso Ltd\") fills "
+        + "EVERY control with that tag, which is what a template that repeats a field expects; pass "
+        + "id=... instead to hit exactly one. "
+        + "content-control(get, session_id, tag=\"CustomerName\") reads them back. "
+        + "content-control(add, session_id, paragraph_index=2, type=\"rich-text\", tag=\"Notes\") "
+        + "creates a new control around a paragraph. "
+        + "content-control(delete, session_id, tag=\"Draft\", delete_contents=false) removes the "
+        + "control and by default keeps its text in the document. "
+        + "A checkbox is set with is_checked=true rather than text, and a control whose contents are "
+        + "locked is reported as such instead of being silently skipped.")]
+public interface IContentControlCommands
+{
+    /// <summary>
+    /// Lists the content controls of the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="tag">Restrict the listing to controls carrying this tag.</param>
+    /// <param name="maxTextLength">Maximum text length per entry.</param>
+    /// <returns>The content controls.</returns>
+    [ServiceAction("list")]
+    ContentControlListResult List(IWordBatch batch, string? tag = null, int maxTextLength = 500);
+
+    /// <summary>
+    /// Reads the content controls addressed by tag or id.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="tag">The tag to look for.</param>
+    /// <param name="id">The Word identifier of a single control.</param>
+    /// <param name="maxTextLength">Maximum text length per entry.</param>
+    /// <returns>The matching content controls.</returns>
+    [ServiceAction("get")]
+    ContentControlResult Get(IWordBatch batch, string? tag = null, string? id = null, int maxTextLength = 5000);
+
+    /// <summary>
+    /// Fills the content controls addressed by tag or id.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="text">The text to write. Ignored for checkbox controls.</param>
+    /// <param name="tag">The tag to look for; every match is updated.</param>
+    /// <param name="id">The Word identifier of a single control.</param>
+    /// <param name="isChecked">Tick state for checkbox controls.</param>
+    /// <returns>The controls after the change.</returns>
+    [ServiceAction("set-text")]
+    ContentControlResult SetText(
+        IWordBatch batch,
+        string? text = null,
+        string? tag = null,
+        string? id = null,
+        bool? isChecked = null);
+
+    /// <summary>
+    /// Wraps a paragraph in a new content control.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="paragraphIndex">1-based index of the paragraph to wrap.</param>
+    /// <param name="type">The control type, for example <c>rich-text</c> or <c>text</c>.</param>
+    /// <param name="tag">The tag to assign.</param>
+    /// <param name="title">The title shown in Word.</param>
+    /// <returns>The control that was created.</returns>
+    [ServiceAction("add")]
+    ContentControlResult Add(
+        IWordBatch batch,
+        int paragraphIndex,
+        string type = "rich-text",
+        string? tag = null,
+        string? title = null);
+
+    /// <summary>
+    /// Removes the content controls addressed by tag or id.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="tag">The tag to look for; every match is removed.</param>
+    /// <param name="id">The Word identifier of a single control.</param>
+    /// <param name="deleteContents">Also delete the text inside the control.</param>
+    /// <returns>The controls that were removed.</returns>
+    [ServiceAction("delete")]
+    ContentControlResult Delete(IWordBatch batch, string? tag = null, string? id = null, bool deleteContents = false);
+}

--- a/src/WordMcp.Core/Commands/Footnote/FootnoteCommands.cs
+++ b/src/WordMcp.Core/Commands/Footnote/FootnoteCommands.cs
@@ -1,0 +1,256 @@
+using System.Runtime.InteropServices;
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Models;
+using WordMcp.Core.Utilities;
+
+namespace WordMcp.Core.Commands.Footnote;
+
+/// <summary>
+/// Word COM implementation of <see cref="IFootnoteCommands"/>.
+/// </summary>
+public sealed class FootnoteCommands : IFootnoteCommands
+{
+    /// <inheritdoc />
+    public FootnoteListResult List(IWordBatch batch, string kind = "footnote", int maxTextLength = 500)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(maxTextLength, 1);
+
+        string normalized = NormalizeKind(kind);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic notes = Collection(doc, normalized);
+            int total = (int)notes.Count;
+
+            var list = new List<FootnoteInfo>();
+
+            for (int i = 1; i <= total; i++)
+            {
+                ct.ThrowIfCancellationRequested();
+                list.Add(Describe(doc, notes[i], i, normalized, maxTextLength));
+            }
+
+            return new FootnoteListResult
+            {
+                Kind = normalized,
+                TotalCount = total,
+                Notes = list
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public FootnoteResult Add(
+        IWordBatch batch,
+        int paragraphIndex,
+        string text,
+        string kind = "footnote",
+        string? anchorText = null)
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(paragraphIndex, 1);
+        ArgumentException.ThrowIfNullOrWhiteSpace(text);
+
+        string normalized = NormalizeKind(kind);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            int paragraphs = (int)doc.Paragraphs.Count;
+
+            if (paragraphIndex > paragraphs)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(paragraphIndex),
+                    $"Paragraph {paragraphIndex} does not exist. The document has {paragraphs} paragraph(s).");
+            }
+
+            dynamic range = Anchor(doc, paragraphIndex, anchorText);
+            dynamic notes = Collection(doc, normalized);
+
+            // The second argument is a custom reference mark; omitting it keeps Word's automatic
+            // numbering, which is what a caller who passes no mark expects.
+            dynamic note = notes.Add(range, Type.Missing, text);
+
+            int index = (int)note.Index;
+
+            return new FootnoteResult
+            {
+                Note = Describe(doc, note, index, normalized, 500),
+                TotalCount = (int)Collection(doc, normalized).Count,
+                Message = $"Added {normalized} {index} to paragraph {paragraphIndex}."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public FootnoteResult SetText(IWordBatch batch, int index, string text, string kind = "footnote")
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(index, 1);
+        ArgumentNullException.ThrowIfNull(text);
+
+        string normalized = NormalizeKind(kind);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic note = Require(doc, normalized, index);
+
+            note.Range.Text = text;
+
+            return new FootnoteResult
+            {
+                Note = Describe(doc, Collection(doc, normalized)[index], index, normalized, 500),
+                TotalCount = (int)Collection(doc, normalized).Count,
+                Message = $"Rewrote {normalized} {index}."
+            };
+        });
+    }
+
+    /// <inheritdoc />
+    public FootnoteResult Delete(IWordBatch batch, int index, string kind = "footnote")
+    {
+        ArgumentNullException.ThrowIfNull(batch);
+        ArgumentOutOfRangeException.ThrowIfLessThan(index, 1);
+
+        string normalized = NormalizeKind(kind);
+
+        return batch.Execute((ctx, ct) =>
+        {
+            dynamic doc = ctx.Document;
+            dynamic note = Require(doc, normalized, index);
+
+            var info = Describe(doc, note, index, normalized, 500);
+            note.Delete();
+
+            int left = (int)Collection(doc, normalized).Count;
+
+            return new FootnoteResult
+            {
+                Note = info,
+                TotalCount = left,
+                Message = left == 0
+                    ? $"Deleted {normalized} {index}."
+                    : $"Deleted {normalized} {index}; Word renumbered the remaining {left}."
+            };
+        });
+    }
+
+    /// <summary>
+    /// Footnotes and endnotes are separate collections in Word, so the kind decides which one every
+    /// action works on.
+    /// </summary>
+    private static string NormalizeKind(string kind)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(kind);
+
+        return kind.Trim().ToLowerInvariant() switch
+        {
+            "footnote" or "footnotes" => "footnote",
+            "endnote" or "endnotes" => "endnote",
+            _ => throw new ArgumentException(
+                $"Unknown note kind '{kind}'. Use one of: footnote, endnote.", nameof(kind))
+        };
+    }
+
+    private static dynamic Collection(dynamic doc, string kind)
+        => kind == "endnote" ? doc.Endnotes : doc.Footnotes;
+
+    private static dynamic Require(dynamic doc, string kind, int index)
+    {
+        dynamic notes = Collection(doc, kind);
+        int total = (int)notes.Count;
+
+        if (index > total)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(index),
+                total == 0
+                    ? $"The document has no {kind}s."
+                    : $"{kind} {index} does not exist. The document has {total}.");
+        }
+
+        return notes[index];
+    }
+
+    /// <summary>
+    /// Resolves where the reference mark goes: after a phrase, or at the end of the paragraph text.
+    /// </summary>
+    private static dynamic Anchor(dynamic doc, int paragraphIndex, string? anchorText)
+    {
+        dynamic paragraph = doc.Paragraphs[paragraphIndex].Range;
+
+        if (!string.IsNullOrEmpty(anchorText))
+        {
+            string paragraphText = WordConversions.CleanRangeText((string?)paragraph.Text);
+            int offset = paragraphText.IndexOf(anchorText, StringComparison.Ordinal);
+
+            if (offset < 0)
+            {
+                throw new ArgumentException(
+                    $"Paragraph {paragraphIndex} does not contain '{anchorText}'.", nameof(anchorText));
+            }
+
+            int end = (int)paragraph.Start + offset + anchorText.Length;
+            return doc.Range(end, end);
+        }
+
+        // A paragraph range ends after its mark. Anchoring there would push the reference into the
+        // next paragraph, so it is placed just before the mark instead.
+        int start = (int)paragraph.Start;
+        int position = Math.Max(start, (int)paragraph.End - 1);
+
+        return doc.Range(position, position);
+    }
+
+    private static FootnoteInfo Describe(dynamic doc, dynamic note, int index, string kind, int maxTextLength)
+    {
+        string text = WordConversions.CleanRangeText((string?)note.Range.Text);
+
+        return new FootnoteInfo
+        {
+            Index = index,
+            Kind = kind,
+            Reference = ReferenceMark(note),
+            ParagraphIndex = ParagraphIndexOf(doc, note),
+            Text = text.Length > maxTextLength ? text[..maxTextLength] : text
+        };
+    }
+
+    private static string ReferenceMark(dynamic note)
+    {
+        try
+        {
+            return WordConversions.CleanRangeText((string?)note.Reference.Text);
+        }
+        catch (COMException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private static int ParagraphIndexOf(dynamic doc, dynamic note)
+    {
+        try
+        {
+            int start = (int)note.Reference.Start;
+            int count = (int)doc.Paragraphs.Count;
+
+            for (int i = 1; i <= count; i++)
+            {
+                dynamic range = doc.Paragraphs[i].Range;
+                if (start >= (int)range.Start && start < (int)range.End)
+                    return i;
+            }
+        }
+        catch (COMException)
+        {
+            // Falling back to 0 keeps the rest of the note usable.
+        }
+
+        return 0;
+    }
+}

--- a/src/WordMcp.Core/Commands/Footnote/IFootnoteCommands.cs
+++ b/src/WordMcp.Core/Commands/Footnote/IFootnoteCommands.cs
@@ -1,0 +1,83 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Attributes;
+using WordMcp.Core.Models;
+
+namespace WordMcp.Core.Commands.Footnote;
+
+/// <summary>
+/// Footnote and endnote operations.
+/// </summary>
+/// <remarks>
+/// Footnotes live in their own story, which is why <c>text(get)</c> never returns them: a document
+/// with footnotes looks complete to a reader of the body text while part of its content is missing.
+/// Every action takes a <c>kind</c> of <c>footnote</c> or <c>endnote</c>, because the two are
+/// separate collections in Word with independent numbering.
+/// </remarks>
+[ServiceCategory("footnote", "Footnote")]
+[McpTool("footnote",
+    Title = "Footnote and Endnote Operations",
+    Description = "Footnote and endnote operations on an open document. "
+        + "IMPORTANT: text(get) does NOT include footnotes - they live in a separate story - so a "
+        + "document that carries its sources in footnotes looks complete while it is not. Call "
+        + "footnote(list, session_id) before summarising or translating a document. "
+        + "footnote(add, session_id, paragraph_index=3, text=\"See annual report 2025, p. 14.\") "
+        + "appends a reference mark at the end of that paragraph; pass anchor_text to attach it "
+        + "directly after a phrase instead. "
+        + "footnote(set-text, session_id, index=2, text=\"...\") rewrites one note. "
+        + "footnote(delete, session_id, index=2) removes the note and its mark, and Word renumbers "
+        + "the rest - so when deleting several, work from the highest index downwards. "
+        + "kind='endnote' addresses endnotes, a separate collection with its own numbering; every "
+        + "action defaults to footnotes.")]
+public interface IFootnoteCommands
+{
+    /// <summary>
+    /// Lists the footnotes or endnotes of the document.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="kind">Either <c>footnote</c> or <c>endnote</c>.</param>
+    /// <param name="maxTextLength">Maximum note text length per entry.</param>
+    /// <returns>The notes.</returns>
+    [ServiceAction("list")]
+    FootnoteListResult List(IWordBatch batch, string kind = "footnote", int maxTextLength = 500);
+
+    /// <summary>
+    /// Adds a footnote or endnote to a paragraph.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="paragraphIndex">1-based index of the paragraph to attach the mark to.</param>
+    /// <param name="text">The note text.</param>
+    /// <param name="kind">Either <c>footnote</c> or <c>endnote</c>.</param>
+    /// <param name="anchorText">
+    /// Place the mark directly after this phrase inside the paragraph. Appended at the end of the
+    /// paragraph when omitted.
+    /// </param>
+    /// <returns>The note that was added.</returns>
+    [ServiceAction("add")]
+    FootnoteResult Add(
+        IWordBatch batch,
+        int paragraphIndex,
+        string text,
+        string kind = "footnote",
+        string? anchorText = null);
+
+    /// <summary>
+    /// Replaces the text of a footnote or endnote.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based index of the note.</param>
+    /// <param name="text">The new note text.</param>
+    /// <param name="kind">Either <c>footnote</c> or <c>endnote</c>.</param>
+    /// <returns>The note after the change.</returns>
+    [ServiceAction("set-text")]
+    FootnoteResult SetText(IWordBatch batch, int index, string text, string kind = "footnote");
+
+    /// <summary>
+    /// Deletes a footnote or endnote together with its reference mark.
+    /// </summary>
+    /// <param name="batch">The Word batch to operate on.</param>
+    /// <param name="index">1-based index of the note.</param>
+    /// <param name="kind">Either <c>footnote</c> or <c>endnote</c>.</param>
+    /// <returns>The number of notes left.</returns>
+    [ServiceAction("delete")]
+    FootnoteResult Delete(IWordBatch batch, int index, string kind = "footnote");
+}

--- a/src/WordMcp.Core/Models/ContentControlResults.cs
+++ b/src/WordMcp.Core/Models/ContentControlResults.cs
@@ -1,0 +1,64 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Metadata for a single content control.
+/// </summary>
+public sealed class ContentControlInfo
+{
+    /// <summary>Gets or sets the 1-based index in the document's content control collection.</summary>
+    public int Index { get; set; }
+
+    /// <summary>Gets or sets the Word-assigned identifier, stable for the lifetime of the control.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the tag, the machine-readable name a template uses.</summary>
+    public string Tag { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the title shown to the user in Word.</summary>
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the control type, for example <c>rich-text</c> or <c>checkbox</c>.</summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the current text, shortened for listings.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets a value indicating whether the content is locked against editing.</summary>
+    public bool LockContents { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether the control itself cannot be deleted.</summary>
+    public bool LockContentControl { get; set; }
+
+    /// <summary>Gets or sets a value indicating whether a checkbox control is ticked.</summary>
+    public bool? Checked { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the control still shows its placeholder rather than
+    /// entered content.
+    /// </summary>
+    public bool ShowingPlaceholderText { get; set; }
+}
+
+/// <summary>
+/// The content controls of a document.
+/// </summary>
+public sealed class ContentControlListResult : ResultBase
+{
+    /// <summary>Gets or sets the number of content controls found.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets the content controls.</summary>
+    public IReadOnlyList<ContentControlInfo> Controls { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation on one or more content controls.
+/// </summary>
+public sealed class ContentControlResult : ResultBase
+{
+    /// <summary>Gets or sets the controls the operation acted on.</summary>
+    public IReadOnlyList<ContentControlInfo> Controls { get; set; } = [];
+
+    /// <summary>Gets or sets the number of controls the operation acted on.</summary>
+    public int AffectedCount { get; set; }
+}

--- a/src/WordMcp.Core/Models/FootnoteResults.cs
+++ b/src/WordMcp.Core/Models/FootnoteResults.cs
@@ -1,0 +1,49 @@
+namespace WordMcp.Core.Models;
+
+/// <summary>
+/// Metadata for a single footnote or endnote.
+/// </summary>
+public sealed class FootnoteInfo
+{
+    /// <summary>Gets or sets the 1-based index within its collection.</summary>
+    public int Index { get; set; }
+
+    /// <summary>Gets or sets the note kind, either <c>footnote</c> or <c>endnote</c>.</summary>
+    public string Kind { get; set; } = "footnote";
+
+    /// <summary>Gets or sets the reference mark as Word renders it, for example <c>1</c> or <c>*</c>.</summary>
+    public string Reference { get; set; } = string.Empty;
+
+    /// <summary>Gets or sets the 1-based index of the body paragraph the mark sits in.</summary>
+    public int ParagraphIndex { get; set; }
+
+    /// <summary>Gets or sets the note text, shortened for the listing.</summary>
+    public string Text { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// The footnotes or endnotes of a document.
+/// </summary>
+public sealed class FootnoteListResult : ResultBase
+{
+    /// <summary>Gets or sets the note kind that was listed.</summary>
+    public string Kind { get; set; } = "footnote";
+
+    /// <summary>Gets or sets the number of notes of that kind.</summary>
+    public int TotalCount { get; set; }
+
+    /// <summary>Gets or sets the notes.</summary>
+    public IReadOnlyList<FootnoteInfo> Notes { get; set; } = [];
+}
+
+/// <summary>
+/// Result of an operation on a single footnote or endnote.
+/// </summary>
+public sealed class FootnoteResult : ResultBase
+{
+    /// <summary>Gets or sets the note the operation acted on.</summary>
+    public FootnoteInfo? Note { get; set; }
+
+    /// <summary>Gets or sets the number of notes of that kind left in the document.</summary>
+    public int TotalCount { get; set; }
+}

--- a/src/WordMcp.Core/Utilities/WordConversions.cs
+++ b/src/WordMcp.Core/Utilities/WordConversions.cs
@@ -350,6 +350,56 @@ public static class WordConversions
         _ => "other"
     };
 
+    /// <summary>
+    /// Converts a <c>WdContentControlType</c> value to its friendly name.
+    /// </summary>
+    /// <param name="wdContentControlType">The Word content control type constant.</param>
+    /// <returns>The friendly content control type name.</returns>
+    public static string FromWdContentControlType(int wdContentControlType) => wdContentControlType switch
+    {
+        ComInteropConstants.WdContentControlRichText => "rich-text",
+        ComInteropConstants.WdContentControlText => "text",
+        ComInteropConstants.WdContentControlPicture => "picture",
+        ComInteropConstants.WdContentControlComboBox => "combo-box",
+        ComInteropConstants.WdContentControlDropdownList => "dropdown-list",
+        ComInteropConstants.WdContentControlBuildingBlockGallery => "building-block-gallery",
+        ComInteropConstants.WdContentControlDate => "date",
+        ComInteropConstants.WdContentControlGroup => "group",
+        ComInteropConstants.WdContentControlCheckBox => "checkbox",
+        ComInteropConstants.WdContentControlRepeatingSection => "repeating-section",
+        _ => "other"
+    };
+
+    /// <summary>
+    /// Converts a content control type name to the matching <c>WdContentControlType</c> value.
+    /// </summary>
+    /// <param name="contentControlType">One of the names returned by <see cref="FromWdContentControlType"/>.</param>
+    /// <returns>The Word content control type constant.</returns>
+    /// <exception cref="ArgumentException">The type name is unknown.</exception>
+    public static int ToWdContentControlType(string contentControlType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(contentControlType);
+
+        return NormalizeName(contentControlType) switch
+        {
+            "rich-text" or "richtext" => ComInteropConstants.WdContentControlRichText,
+            "text" or "plain-text" or "plaintext" => ComInteropConstants.WdContentControlText,
+            "picture" or "image" => ComInteropConstants.WdContentControlPicture,
+            "combo-box" or "combobox" => ComInteropConstants.WdContentControlComboBox,
+            "dropdown-list" or "dropdownlist" or "dropdown" => ComInteropConstants.WdContentControlDropdownList,
+            "building-block-gallery" or "buildingblockgallery" => ComInteropConstants.WdContentControlBuildingBlockGallery,
+            "date" => ComInteropConstants.WdContentControlDate,
+            "group" => ComInteropConstants.WdContentControlGroup,
+            "checkbox" or "check-box" => ComInteropConstants.WdContentControlCheckBox,
+            "repeating-section" or "repeatingsection" => ComInteropConstants.WdContentControlRepeatingSection,
+            _ => throw new ArgumentException(
+                $"Unknown content control type '{contentControlType}'. Use one of: rich-text, text, "
+                + "picture, combo-box, dropdown-list, building-block-gallery, date, group, checkbox, "
+                + "repeating-section.",
+                nameof(contentControlType))
+        };
+    }
+
     private static string NormalizeName(string value)
         => value.Trim().ToLowerInvariant().Replace('_', '-').Replace(" ", string.Empty, StringComparison.Ordinal);
 }

--- a/tests/WordMcp.Core.Tests/ContentControlIntegrationTests.cs
+++ b/tests/WordMcp.Core.Tests/ContentControlIntegrationTests.cs
@@ -1,0 +1,175 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.ContentControl;
+using WordMcp.Core.Commands.Paragraph;
+using WordMcp.Core.Commands.Text;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Integration tests for the content control commands against a real Word instance.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class ContentControlIntegrationTests : IDisposable
+{
+    private static readonly ContentControlCommands Controls = new();
+    private static readonly ParagraphCommands Paragraphs = new();
+    private static readonly TextCommands Texts = new();
+
+    private readonly SessionManager _sessions = new();
+    private readonly string _directory;
+    private readonly string _sessionId;
+
+    private IWordBatch Batch => _sessions.GetBatch(_sessionId);
+
+    public ContentControlIntegrationTests()
+    {
+        _directory = Directory
+            .CreateDirectory(Path.Combine(Path.GetTempPath(), "wordmcp-cc-" + Guid.NewGuid().ToString("N")))
+            .FullName;
+
+        _sessionId = _sessions.Create(Path.Combine(_directory, "controls.docx")).SessionId;
+    }
+
+    [Fact]
+    public void ContentControl_AddListSetTextAndDeleteRoundTrip()
+    {
+        int index = Paragraphs.Add(Batch, "Placeholder for the customer.").Paragraph!.Index;
+
+        var added = Controls.Add(Batch, index, "rich-text", "CustomerName", "Customer");
+
+        Assert.True(added.Success);
+        Assert.Equal(1, added.AffectedCount);
+        Assert.Equal("CustomerName", added.Controls[0].Tag);
+        Assert.Equal("Customer", added.Controls[0].Title);
+        Assert.Equal("rich-text", added.Controls[0].Type);
+        Assert.NotEmpty(added.Controls[0].Id);
+
+        var list = Controls.List(Batch);
+        Assert.Equal(1, list.TotalCount);
+        Assert.Equal("CustomerName", list.Controls[0].Tag);
+
+        var filled = Controls.SetText(Batch, "Contoso Ltd", "CustomerName");
+        Assert.Equal(1, filled.AffectedCount);
+        Assert.Equal("Contoso Ltd", filled.Controls[0].Text);
+
+        Assert.Equal("Contoso Ltd", Controls.Get(Batch, "CustomerName").Controls[0].Text);
+        Assert.Contains("Contoso Ltd", Texts.Get(Batch).Text, StringComparison.Ordinal);
+
+        var deleted = Controls.Delete(Batch, "CustomerName");
+        Assert.Equal(1, deleted.AffectedCount);
+        Assert.Empty(Controls.List(Batch).Controls);
+
+        // Deleting the control alone must leave the text behind.
+        Assert.Contains("Contoso Ltd", Texts.Get(Batch).Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ContentControl_SetTextByTagFillsEveryMatch()
+    {
+        int first = Paragraphs.Add(Batch, "Header name.").Paragraph!.Index;
+        int second = Paragraphs.Add(Batch, "Signature name.").Paragraph!.Index;
+
+        Controls.Add(Batch, first, "rich-text", "CustomerName");
+        Controls.Add(Batch, second, "rich-text", "CustomerName");
+
+        var filled = Controls.SetText(Batch, "Contoso Ltd", "CustomerName");
+
+        Assert.Equal(2, filled.AffectedCount);
+        Assert.All(filled.Controls, c => Assert.Equal("Contoso Ltd", c.Text));
+    }
+
+    [Fact]
+    public void ContentControl_SetTextByIdHitsExactlyOne()
+    {
+        int first = Paragraphs.Add(Batch, "Header name.").Paragraph!.Index;
+        int second = Paragraphs.Add(Batch, "Signature name.").Paragraph!.Index;
+
+        string id = Controls.Add(Batch, first, "rich-text", "CustomerName").Controls[0].Id;
+        Controls.Add(Batch, second, "rich-text", "CustomerName");
+
+        var filled = Controls.SetText(Batch, "Only here", null, id);
+
+        Assert.Equal(1, filled.AffectedCount);
+        Assert.Equal("Only here", filled.Controls[0].Text);
+        Assert.Contains(Controls.Get(Batch, "CustomerName").Controls, c => c.Text != "Only here");
+    }
+
+    [Fact]
+    public void ContentControl_DeleteWithContentsRemovesTheText()
+    {
+        int index = Paragraphs.Add(Batch, "Draft note to remove.").Paragraph!.Index;
+        Controls.Add(Batch, index, "rich-text", "Draft");
+
+        Controls.Delete(Batch, "Draft", null, deleteContents: true);
+
+        Assert.DoesNotContain("Draft note to remove.", Texts.Get(Batch).Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ContentControl_ListCanBeFilteredByTag()
+    {
+        int first = Paragraphs.Add(Batch, "Customer.").Paragraph!.Index;
+        int second = Paragraphs.Add(Batch, "Project.").Paragraph!.Index;
+
+        Controls.Add(Batch, first, "rich-text", "CustomerName");
+        Controls.Add(Batch, second, "rich-text", "ProjectName");
+
+        Assert.Equal(2, Controls.List(Batch).TotalCount);
+        Assert.Equal(1, Controls.List(Batch, "ProjectName").TotalCount);
+    }
+
+    [Fact]
+    public void ContentControl_UnknownTagIsRejected()
+    {
+        Paragraphs.Add(Batch, "Nothing tagged here.");
+
+        Assert.Throws<ArgumentException>(() => Controls.Get(Batch, "Missing"));
+        Assert.Throws<ArgumentException>(() => Controls.SetText(Batch, "x", "Missing"));
+        Assert.Throws<ArgumentException>(() => Controls.Delete(Batch, "Missing"));
+    }
+
+    [Fact]
+    public void ContentControl_ParagraphBeyondTheDocumentIsRejected()
+    {
+        Paragraphs.Add(Batch, "One paragraph.");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Controls.Add(Batch, 999));
+    }
+
+    [Fact]
+    public void ContentControl_PlainTextControlAcceptsText()
+    {
+        int index = Paragraphs.Add(Batch, "Plain value.").Paragraph!.Index;
+
+        Controls.Add(Batch, index, "text", "Reference");
+        var filled = Controls.SetText(Batch, "INV-2025-0042", "Reference");
+
+        Assert.Equal("text", filled.Controls[0].Type);
+        Assert.Equal("INV-2025-0042", filled.Controls[0].Text);
+    }
+
+    [Fact]
+    public void ContentControl_ListReportsAnEmptyDocumentWithoutFailing()
+    {
+        var list = Controls.List(Batch);
+
+        Assert.True(list.Success);
+        Assert.Equal(0, list.TotalCount);
+        Assert.Empty(list.Controls);
+    }
+
+    public void Dispose()
+    {
+        _sessions.Dispose();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A locked temp file must not fail the test run.
+        }
+    }
+}

--- a/tests/WordMcp.Core.Tests/ContentControlValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/ContentControlValidationTests.cs
@@ -1,0 +1,102 @@
+using WordMcp.Core.Commands.ContentControl;
+using WordMcp.Core.Utilities;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Argument validation of the content control commands. Everything asserted here happens before the
+/// batch is touched, so these tests need no Word installation and run in CI.
+/// </summary>
+public class ContentControlValidationTests
+{
+    private static readonly ContentControlCommands Controls = new();
+    private static readonly ThrowingBatch Batch = new();
+
+    [Fact]
+    public void List_WorksWithoutASelector()
+        => Assert.Throws<NotSupportedException>(() => Controls.List(Batch));
+
+    [Fact]
+    public void List_RejectsMaxTextLengthBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Controls.List(Batch, null, 0));
+
+    [Fact]
+    public void Get_RequiresATagOrAnId()
+        => Assert.Throws<ArgumentException>(() => Controls.Get(Batch));
+
+    [Fact]
+    public void Get_RejectsABlankTag()
+        => Assert.Throws<ArgumentException>(() => Controls.Get(Batch, "   "));
+
+    [Theory]
+    [InlineData("CustomerName", null)]
+    [InlineData(null, "123456789")]
+    public void Get_AcceptsEitherSelector(string? tag, string? id)
+        => Assert.Throws<NotSupportedException>(() => Controls.Get(Batch, tag, id));
+
+    [Fact]
+    public void SetText_RequiresASelector()
+        => Assert.Throws<ArgumentException>(() => Controls.SetText(Batch, "Contoso"));
+
+    [Fact]
+    public void SetText_RequiresTextOrACheckState()
+        => Assert.Throws<ArgumentException>(() => Controls.SetText(Batch, null, "CustomerName"));
+
+    [Fact]
+    public void SetText_AcceptsACheckStateWithoutText()
+        => Assert.Throws<NotSupportedException>(() => Controls.SetText(Batch, null, "Agreed", null, true));
+
+    [Fact]
+    public void SetText_AcceptsEmptyTextToClearAControl()
+        => Assert.Throws<NotSupportedException>(() => Controls.SetText(Batch, string.Empty, "CustomerName"));
+
+    [Fact]
+    public void Add_RejectsParagraphIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Controls.Add(Batch, 0));
+
+    [Fact]
+    public void Add_RejectsAnUnknownType()
+        => Assert.Throws<ArgumentException>(() => Controls.Add(Batch, 1, "spinner"));
+
+    [Theory]
+    [InlineData("rich-text")]
+    [InlineData("text")]
+    [InlineData("Plain Text")]
+    [InlineData("checkbox")]
+    [InlineData("dropdown_list")]
+    [InlineData("date")]
+    public void Add_AcceptsTheDocumentedTypes(string type)
+        => Assert.Throws<NotSupportedException>(() => Controls.Add(Batch, 1, type, "Notes", "Notes"));
+
+    [Fact]
+    public void Delete_RequiresASelector()
+        => Assert.Throws<ArgumentException>(() => Controls.Delete(Batch));
+
+    [Fact]
+    public void Delete_AcceptsATag()
+        => Assert.Throws<NotSupportedException>(() => Controls.Delete(Batch, "Draft", null, true));
+
+    [Fact]
+    public void TypeNamesRoundTrip()
+    {
+        foreach (string name in new[]
+                 {
+                     "rich-text", "text", "picture", "combo-box", "dropdown-list",
+                     "building-block-gallery", "date", "group", "checkbox", "repeating-section"
+                 })
+        {
+            Assert.Equal(name, WordConversions.FromWdContentControlType(WordConversions.ToWdContentControlType(name)));
+        }
+    }
+
+    [Fact]
+    public void AllCommandsRejectNullBatch()
+    {
+        Assert.Throws<ArgumentNullException>(() => Controls.List(null!));
+        Assert.Throws<ArgumentNullException>(() => Controls.Get(null!, "Tag"));
+        Assert.Throws<ArgumentNullException>(() => Controls.SetText(null!, "Text", "Tag"));
+        Assert.Throws<ArgumentNullException>(() => Controls.Add(null!, 1));
+        Assert.Throws<ArgumentNullException>(() => Controls.Delete(null!, "Tag"));
+    }
+}

--- a/tests/WordMcp.Core.Tests/FootnoteIntegrationTests.cs
+++ b/tests/WordMcp.Core.Tests/FootnoteIntegrationTests.cs
@@ -1,0 +1,167 @@
+using WordMcp.ComInterop.Session;
+using WordMcp.Core.Commands.Footnote;
+using WordMcp.Core.Commands.Paragraph;
+using WordMcp.Core.Commands.Text;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Integration tests for the footnote commands against a real Word instance.
+/// </summary>
+[Trait("Category", "RequiresWord")]
+public sealed class FootnoteIntegrationTests : IDisposable
+{
+    private static readonly FootnoteCommands Footnotes = new();
+    private static readonly ParagraphCommands Paragraphs = new();
+    private static readonly TextCommands Texts = new();
+
+    private readonly SessionManager _sessions = new();
+    private readonly string _directory;
+    private readonly string _sessionId;
+
+    private IWordBatch Batch => _sessions.GetBatch(_sessionId);
+
+    public FootnoteIntegrationTests()
+    {
+        _directory = Directory
+            .CreateDirectory(Path.Combine(Path.GetTempPath(), "wordmcp-footnote-" + Guid.NewGuid().ToString("N")))
+            .FullName;
+
+        _sessionId = _sessions.Create(Path.Combine(_directory, "footnotes.docx")).SessionId;
+    }
+
+    [Fact]
+    public void Footnote_AddListSetTextAndDeleteRoundTrip()
+    {
+        int index = Paragraphs.Add(Batch, "Revenue grew by fifteen percent.").Paragraph!.Index;
+
+        var added = Footnotes.Add(Batch, index, "Annual report 2025, page 14.");
+
+        Assert.True(added.Success);
+        Assert.Equal(1, added.Note!.Index);
+        Assert.Equal("footnote", added.Note.Kind);
+        Assert.Equal(index, added.Note.ParagraphIndex);
+        Assert.Contains("Annual report 2025", added.Note.Text, StringComparison.Ordinal);
+        Assert.Equal(1, added.TotalCount);
+
+        var list = Footnotes.List(Batch);
+        Assert.Equal(1, list.TotalCount);
+        Assert.Contains(list.Notes, n => n.Text.Contains("Annual report 2025", StringComparison.Ordinal));
+
+        var changed = Footnotes.SetText(Batch, 1, "Quarterly report Q4, page 3.");
+        Assert.Contains("Quarterly report Q4", changed.Note!.Text, StringComparison.Ordinal);
+
+        var deleted = Footnotes.Delete(Batch, 1);
+        Assert.Equal(0, deleted.TotalCount);
+        Assert.Empty(Footnotes.List(Batch).Notes);
+    }
+
+    [Fact]
+    public void Footnote_TextGetDoesNotContainTheNoteText()
+    {
+        int index = Paragraphs.Add(Batch, "The body sentence stays visible.").Paragraph!.Index;
+        Footnotes.Add(Batch, index, "Only reachable through the footnote tool.");
+
+        string body = Texts.Get(Batch).Text;
+
+        Assert.Contains("The body sentence stays visible.", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("Only reachable through the footnote tool.", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Footnote_EndnotesAreASeparateCollection()
+    {
+        int index = Paragraphs.Add(Batch, "A claim that needs two sources.").Paragraph!.Index;
+
+        Footnotes.Add(Batch, index, "Footnote source.");
+        Footnotes.Add(Batch, index, "Endnote source.", "endnote");
+
+        var footnotes = Footnotes.List(Batch);
+        var endnotes = Footnotes.List(Batch, "endnote");
+
+        Assert.Equal(1, footnotes.TotalCount);
+        Assert.Equal(1, endnotes.TotalCount);
+        Assert.Equal("endnote", endnotes.Notes[0].Kind);
+        Assert.Contains("Endnote source.", endnotes.Notes[0].Text, StringComparison.Ordinal);
+        Assert.DoesNotContain(footnotes.Notes, n => n.Text.Contains("Endnote source.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Footnote_AnchorTextPlacesTheMarkAfterThePhrase()
+    {
+        int index = Paragraphs.Add(Batch, "Growth was strong although costs rose.").Paragraph!.Index;
+
+        Footnotes.Add(Batch, index, "Measured year over year.", "footnote", "strong");
+
+        var note = Footnotes.List(Batch).Notes[0];
+        Assert.Equal(index, note.ParagraphIndex);
+    }
+
+    [Fact]
+    public void Footnote_AnchorTextThatIsAbsentIsRejected()
+    {
+        int index = Paragraphs.Add(Batch, "A short paragraph.").Paragraph!.Index;
+
+        Assert.Throws<ArgumentException>(() => Footnotes.Add(Batch, index, "Note.", "footnote", "missing phrase"));
+    }
+
+    [Fact]
+    public void Footnote_UnknownIndexIsRejected()
+    {
+        Paragraphs.Add(Batch, "One paragraph.");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Footnotes.SetText(Batch, 3, "Note."));
+        Assert.Throws<ArgumentOutOfRangeException>(() => Footnotes.Delete(Batch, 1));
+    }
+
+    [Fact]
+    public void Footnote_ParagraphBeyondTheDocumentIsRejected()
+    {
+        Paragraphs.Add(Batch, "One paragraph.");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => Footnotes.Add(Batch, 999, "Note."));
+    }
+
+    [Fact]
+    public void Footnote_DeletingRenumbersTheRest()
+    {
+        int index = Paragraphs.Add(Batch, "A paragraph carrying three notes.").Paragraph!.Index;
+
+        Footnotes.Add(Batch, index, "First note.");
+        Footnotes.Add(Batch, index, "Second note.");
+        Footnotes.Add(Batch, index, "Third note.");
+
+        Assert.Equal(3, Footnotes.List(Batch).TotalCount);
+
+        Footnotes.Delete(Batch, 1);
+
+        var left = Footnotes.List(Batch);
+        Assert.Equal(2, left.TotalCount);
+        Assert.Equal([1, 2], left.Notes.Select(n => n.Index).ToArray());
+        Assert.DoesNotContain(left.Notes, n => n.Text.Contains("First note.", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Footnote_ListShortensLongNoteText()
+    {
+        int index = Paragraphs.Add(Batch, "A paragraph with a long note.").Paragraph!.Index;
+        Footnotes.Add(Batch, index, new string('x', 300));
+
+        Assert.Equal(20, Footnotes.List(Batch, "footnote", 20).Notes[0].Text.Length);
+    }
+
+    public void Dispose()
+    {
+        _sessions.Dispose();
+
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A locked temp file must not fail the test run.
+        }
+    }
+}

--- a/tests/WordMcp.Core.Tests/FootnoteValidationTests.cs
+++ b/tests/WordMcp.Core.Tests/FootnoteValidationTests.cs
@@ -1,0 +1,79 @@
+using WordMcp.Core.Commands.Footnote;
+using Xunit;
+
+namespace WordMcp.Core.Tests;
+
+/// <summary>
+/// Argument validation of the footnote commands. Everything asserted here happens before the batch
+/// is touched, so these tests need no Word installation and run in CI.
+/// </summary>
+public class FootnoteValidationTests
+{
+    private static readonly FootnoteCommands Footnotes = new();
+    private static readonly ThrowingBatch Batch = new();
+
+    [Theory]
+    [InlineData("footnote")]
+    [InlineData("Footnote")]
+    [InlineData(" FOOTNOTES ")]
+    [InlineData("endnote")]
+    [InlineData("Endnotes")]
+    public void List_AcceptsBothNoteKinds(string kind)
+        => Assert.Throws<NotSupportedException>(() => Footnotes.List(Batch, kind));
+
+    [Theory]
+    [InlineData("note")]
+    [InlineData("comment")]
+    [InlineData("foot-note")]
+    public void List_RejectsUnknownNoteKinds(string kind)
+        => Assert.Throws<ArgumentException>(() => Footnotes.List(Batch, kind));
+
+    [Fact]
+    public void List_RejectsEmptyNoteKind()
+        => Assert.Throws<ArgumentException>(() => Footnotes.List(Batch, "   "));
+
+    [Fact]
+    public void List_RejectsMaxTextLengthBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Footnotes.List(Batch, "footnote", 0));
+
+    [Fact]
+    public void Add_RejectsParagraphIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Footnotes.Add(Batch, 0, "Source."));
+
+    [Fact]
+    public void Add_RejectsEmptyText()
+        => Assert.Throws<ArgumentException>(() => Footnotes.Add(Batch, 1, "   "));
+
+    [Fact]
+    public void Add_AcceptsAValidCall()
+        => Assert.Throws<NotSupportedException>(() => Footnotes.Add(Batch, 1, "Source.", "endnote", "phrase"));
+
+    [Fact]
+    public void SetText_RejectsIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Footnotes.SetText(Batch, 0, "Source."));
+
+    [Fact]
+    public void SetText_RejectsNullText()
+        => Assert.Throws<ArgumentNullException>(() => Footnotes.SetText(Batch, 1, null!));
+
+    [Fact]
+    public void SetText_AcceptsEmptyTextToClearANote()
+        => Assert.Throws<NotSupportedException>(() => Footnotes.SetText(Batch, 1, string.Empty));
+
+    [Fact]
+    public void Delete_RejectsIndexBelowOne()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => Footnotes.Delete(Batch, 0));
+
+    [Fact]
+    public void Delete_RejectsUnknownNoteKind()
+        => Assert.Throws<ArgumentException>(() => Footnotes.Delete(Batch, 1, "sidenote"));
+
+    [Fact]
+    public void AllCommandsRejectNullBatch()
+    {
+        Assert.Throws<ArgumentNullException>(() => Footnotes.List(null!));
+        Assert.Throws<ArgumentNullException>(() => Footnotes.Add(null!, 1, "Source."));
+        Assert.Throws<ArgumentNullException>(() => Footnotes.SetText(null!, 1, "Source."));
+        Assert.Throws<ArgumentNullException>(() => Footnotes.Delete(null!, 1));
+    }
+}


### PR DESCRIPTION
Closes #61.

## Why

`text(get)` returns Word's body story and nothing else. A document that carries its sources in
footnotes therefore looked complete while a part of its content was unreachable — an agent
summarising or translating it would silently drop every note. There was no tool that could see them.

Content controls had the mirror problem. They are the structured fields a Word template exposes, and
the only correct way to fill a template. Doing it with `text(replace)` destroys the control and its
data binding, so the server could open a template but not complete one.

## What

**`footnote`** — `list`, `add`, `set-text`, `delete`.

Footnotes and endnotes are separate collections in Word with independent numbering, so they sit
behind one `kind` parameter rather than two tools — the same shape `header-footer` already uses.
`add` appends the reference mark at the end of a paragraph, or directly after a phrase when
`anchor_text` is given, matching `bookmark(add)`.

**`content-control`** — `list`, `get`, `set-text`, `add`, `delete`.

A tag is not unique, and a template that shows the customer name in the header and again in the
signature block relies on that. So `set-text` by `tag` updates **every** match and reports how many;
`id` addresses exactly one. A checkbox takes `is_checked` instead of `text`. A locked control is
reported rather than silently skipped, and `delete` keeps the text unless `delete_contents` is set.

## Verification

18 integration tests against a real Word instance, all green, plus 47 validation tests that run
without Word.

Three things that were assumptions before this branch and are now measured:

- `text(get)` really does omit footnote text — the claim in #61 was never checked.
- Deleting a note renumbers every note after it, the same trap as comments and revisions.
- `ContentControls.Add` works on a freshly created `.docx`; it was unclear whether Word would allow
  it outside a template.

The smoke test now reports 17 tools across the process boundary, so both tools are reachable through
the generated MCP layer and not just from `WordMcp.Core`.

No hand-written wiring: the Roslyn generator produced `WordTool.Footnote.g.cs`,
`WordTool.ContentControl.g.cs` and the matching dispatch from the two interfaces alone.

## Documentation

README gains a section per tool and six entries under "Known behaviour and pitfalls" — chiefly that
`text(get)` never returns footnotes and that filling a template means `content-control(set-text)`,
never `text(replace)`. `skills/word-mcp/SKILL.md` gains the same two warnings.
