### PR TITLE
Add the Copilot app repository configuration

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,0 +1,3 @@
+automation:
+  auto_issue_session: true
+  remote_control: false


### PR DESCRIPTION
The automation settings for the Copilot app only existed on one machine as an untracked file, so a fresh clone silently lost them. Tracking `.github/github-app.yml` keeps the behaviour reproducible across machines.

No code or build changes.